### PR TITLE
fix: separate animation hooks for Mianima page content sections

### DIFF
--- a/src/pages/MianimaPage.tsx
+++ b/src/pages/MianimaPage.tsx
@@ -7,6 +7,7 @@ import { useScrollAnimation } from '@/hooks/useScrollAnimation';
 export function MianimaPage() {
   const heroAnimation = useScrollAnimation({ threshold: 0.2 });
   const contentAnimation = useScrollAnimation({ threshold: 0.3 });
+  const secondContentAnimation = useScrollAnimation({ threshold: 0.3 });
   const successAnimation = useScrollAnimation({ threshold: 0.2 });
 
   return (
@@ -188,13 +189,13 @@ export function MianimaPage() {
       </div>
       {/* Second Content Section */}
       <div 
-        ref={contentAnimation.ref}
+        ref={secondContentAnimation.ref}
         className="py-16 bg-white"
       >
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="max-w-4xl mx-auto">
             <div className={`transition-all duration-1000 ${
-              contentAnimation.isIntersecting ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
+              secondContentAnimation.isIntersecting ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
             }`}>
 
               <p className="text-lg text-gray-700 leading-relaxed mb-8">


### PR DESCRIPTION
## Summary
This PR fixes an animation loading issue on the Mianima page where the top content section wasn't animating on page load.

## Problem
Both content sections (MIANIMA program description and MIANIMA MARKET description) were sharing the same `contentAnimation` hook instance, causing them to have the same `isIntersecting` state. When the second section triggered its animation, it affected both sections, preventing the top content from animating properly on page load.

## Solution
- Created a separate `secondContentAnimation` hook for the second content section
- Updated the second content section to use its own animation state
- Each content section now has independent animation behavior

## Changes
- Added `const secondContentAnimation = useScrollAnimation({ threshold: 0.3 });`
- Updated second content section to use `secondContentAnimation.ref` and `secondContentAnimation.isIntersecting`
- Each section now animates independently when it enters the viewport

## Testing
- [x] Top content section now animates properly on page load
- [x] Second content section animates independently when scrolled into view
- [x] No visual regressions introduced
- [x] All existing functionality preserved

## Result
The Mianima page now provides a better user experience with proper animation timing for each content section.