### PR TITLE
fix(auth): guard portal layout and add /portal index redirect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,7 @@ function App() {
                 <Route path="portal/login" element={<PortalLoginPage />} />
                 <Route path="portal/acceso" element={<PortalAccesoPage />} />
                 <Route path="portal" element={<PortalLayout />}>
+                  <Route index element={<Navigate to="perfil" replace />} />
                   <Route path="perfil" element={<PortalPerfilPage />} />
                   <Route path="suscripcion" element={<PortalSuscripcionPage />} />
                 </Route>

--- a/src/pages/portal/PortalLayout.tsx
+++ b/src/pages/portal/PortalLayout.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation, Outlet } from 'react-router-dom';
+import { Link, useLocation, Outlet, Navigate } from 'react-router-dom';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { usePortalAuth } from '@/hooks/usePortalAuth';
@@ -10,7 +10,19 @@ const navItems = [
 
 export function PortalLayout() {
   const location = useLocation();
-  const { member, logout, isLoggingOut } = usePortalAuth();
+  const { member, logout, isLoggingOut, isLoading, isAuthenticated } = usePortalAuth();
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-900">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-red-500" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/portal/login" replace />;
+  }
 
   return (
     <div className="min-h-screen flex flex-col bg-gray-900">

--- a/src/pages/portal/PortalPerfilPage.tsx
+++ b/src/pages/portal/PortalPerfilPage.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { usePortalAuth } from '@/hooks/usePortalAuth';
 import type { PortalProfileResponse } from '@/types/api';
@@ -27,16 +26,9 @@ async function saveProfile(data: ProfileEditFormData): Promise<{ success: boolea
 }
 
 export function PortalPerfilPage() {
-  const navigate = useNavigate();
-  const { isAuthenticated, isLoading: authLoading, isError: authError } = usePortalAuth();
+  const { isAuthenticated } = usePortalAuth();
   const [isEditing, setIsEditing] = useState(false);
   const queryClient = useQueryClient();
-
-  useEffect(() => {
-    if (!authLoading && !isAuthenticated) {
-      navigate('/portal/login', { replace: true });
-    }
-  }, [isAuthenticated, authLoading, navigate]);
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ['portal', 'profile'],
@@ -55,15 +47,7 @@ export function PortalPerfilPage() {
     },
   });
 
-  if (authLoading || isLoading) {
-    return (
-      <div className="flex justify-center py-16">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-red-500" />
-      </div>
-    );
-  }
-
-  if (authError || (!authLoading && !isAuthenticated)) {
+  if (isLoading) {
     return (
       <div className="flex justify-center py-16">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-red-500" />

--- a/src/pages/portal/PortalSuscripcionPage.tsx
+++ b/src/pages/portal/PortalSuscripcionPage.tsx
@@ -1,20 +1,12 @@
-import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
 import { usePortalAuth } from '@/hooks/usePortalAuth';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 
 export function PortalSuscripcionPage() {
-  const navigate = useNavigate();
-  const { isAuthenticated, isLoading: authLoading, member } = usePortalAuth();
+  const { member } = usePortalAuth();
   const [isRedirecting, setIsRedirecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!authLoading && !isAuthenticated) {
-      navigate('/portal/login', { replace: true });
-    }
-  }, [isAuthenticated, authLoading, navigate]);
 
   const handleManageSubscription = async () => {
     if (!member?.email) return;
@@ -52,14 +44,6 @@ export function PortalSuscripcionPage() {
       setIsRedirecting(false);
     }
   };
-
-  if (authLoading) {
-    return (
-      <div className="flex justify-center py-16">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-red-500" />
-      </div>
-    );
-  }
 
   return (
     <div>


### PR DESCRIPTION
## Changes

- **PortalLayout**: Added authentication guard that redirects unauthenticated users to login and shows loading spinner during auth check
- **App routes**: Added index route redirect from `/portal` to `/portal/perfil`
- **PortalPerfilPage & PortalSuscripcionPage**: Removed redundant auth checks and loading states since they're now handled by PortalLayout guard

## Impact

Centralizes authentication logic at the layout level, eliminating code duplication in child pages and ensuring consistent auth protection across the portal.