### PR TITLE
fix(ui): show cookie banner on all routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { ToastProvider } from './contexts/ToastContext';
 import { LoadingProvider } from './contexts/LoadingContext';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { Layout } from './components/Layout';
+import { useCookieConsent } from './hooks/useCookieConsent';
 import { HomePage } from './pages/HomePage';
 import { AboutPage } from './pages/AboutPage';
 import { MembershipPage } from './pages/MembershipPage';
@@ -23,6 +24,7 @@ import { TerminosUsoPage } from './pages/TerminosUsoPage';
 import { PoliticaPrivacidadPage } from './pages/PoliticaPrivacidadPage';
 
 function App() {
+  useCookieConsent();
   return (
     <ErrorBoundary>
       <LoadingProvider>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,10 +1,8 @@
 import { Outlet } from 'react-router-dom';
 import { Header } from './Header';
 import { Footer } from './Footer';
-import { useCookieConsent } from '@/hooks/useCookieConsent';
 
 export function Layout() {
-  useCookieConsent();
   return (
     <div className="min-h-screen flex flex-col bg-gray-900 dark">
       <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 z-50 bg-red-600 text-white px-4 py-2 rounded-md">


### PR DESCRIPTION
## Summary

- `useCookieConsent()` was called inside `Layout`, which only covers main public routes
- `/registro`, `/registro/exito`, `/portal/login`, `/portal/acceso`, and `/portal/*` are outside `Layout` (they render their own `<Header>`/`<Footer>`) so they never showed the cookie banner
- Fix: move `useCookieConsent()` from `Layout` to `App` — runs once on mount, covers every entrypoint

## Test plan

- [ ] Visit `/registro` directly — cookie banner appears
- [ ] Visit `/portal/login` directly — cookie banner appears
- [ ] Visit `/` — cookie banner still appears (unchanged behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)