### PR TITLE
feat(gallery): implement member gallery with WA API + KV cache

### DIFF
--- a/functions/api/members.ts
+++ b/functions/api/members.ts
@@ -1,0 +1,155 @@
+// GET /api/members — member gallery data, fetched from WildApricot and cached in KV for 1 hour.
+
+import { getWAToken } from '../_lib/wa-token';
+import { FIELD_CODES } from '../_lib/wa-field-ids';
+import { log, logError } from '../_lib/logger';
+
+const KV_KEY = 'gallery_members';
+const CACHE_TTL = 3600; // 1 hour
+
+interface Env {
+  KV: KVNamespace;
+  WILDAPRICOT_API_KEY: string;
+  WILDAPRICOT_ACCOUNT_ID: string;
+  WA_LEVEL_ID_PLENO_DERECHO: string;
+  WA_LEVEL_ID_ESTUDIANTE: string;
+  WA_LEVEL_ID_COLABORADOR: string;
+}
+
+type WAFieldValue = { FieldName?: string; SystemCode: string; Value: unknown };
+
+interface WAContact {
+  Id: number;
+  FirstName: string;
+  LastName: string;
+  DisplayName?: string;
+  MembershipLevel?: { Id: number; Name: string };
+  MemberSince?: string;
+  ProfileImage?: { Url?: string; IsDefault?: boolean };
+  FieldValues?: WAFieldValue[];
+}
+
+function getStringField(fields: WAFieldValue[] | undefined, code: string): string {
+  const raw = fields?.find(f => f.SystemCode === code)?.Value;
+  if (raw === null || raw === undefined) return '';
+  return String(raw).trim();
+}
+
+function getOptionLabel(fields: WAFieldValue[] | undefined, code: string): string {
+  const raw = fields?.find(f => f.SystemCode === code)?.Value;
+  if (!raw || typeof raw !== 'object') return '';
+  return ((raw as { Label?: string }).Label ?? '').trim();
+}
+
+function getOptionLabels(fields: WAFieldValue[] | undefined, code: string): string[] {
+  const raw = fields?.find(f => f.SystemCode === code)?.Value;
+  if (!raw) return [];
+  if (Array.isArray(raw)) {
+    return raw.map(v => ((v as { Label?: string }).Label ?? '').trim()).filter(Boolean);
+  }
+  if (typeof raw === 'object') {
+    const label = ((raw as { Label?: string }).Label ?? '').trim();
+    return label ? [label] : [];
+  }
+  return [];
+}
+
+function normalizeMembershipType(env: Env, level?: { Id: number; Name: string }): string {
+  if (!level) return '';
+  const id = String(level.Id);
+  if (id === env.WA_LEVEL_ID_PLENO_DERECHO) return 'pleno_derecho';
+  if (id === env.WA_LEVEL_ID_ESTUDIANTE) return 'estudiante';
+  if (id === env.WA_LEVEL_ID_COLABORADOR) return 'colaborador';
+  return level.Name?.toLowerCase().replace(/\s+/g, '_') ?? '';
+}
+
+function transformContact(env: Env, contact: WAContact): object {
+  const fields = contact.FieldValues;
+  const photo = contact.ProfileImage;
+  return {
+    id: String(contact.Id),
+    first_name: contact.FirstName,
+    last_name: contact.LastName,
+    display_name: contact.DisplayName,
+    profile_image_url: photo && photo.IsDefault === false ? photo.Url : undefined,
+    biography: getStringField(fields, FIELD_CODES.bio) || undefined,
+    main_profession: getOptionLabel(fields, FIELD_CODES.profesionPrincipal) || undefined,
+    other_professions: getOptionLabels(fields, FIELD_CODES.profesionAdicional),
+    availability_status: getOptionLabel(fields, FIELD_CODES.statusEmpleo) || undefined,
+    city: getStringField(fields, FIELD_CODES.ciudad) || undefined,
+    country: getOptionLabel(fields, FIELD_CODES.pais) || undefined,
+    membership_type: normalizeMembershipType(env, contact.MembershipLevel),
+    created_at: contact.MemberSince,
+    social_media: {
+      linkedin: getStringField(fields, FIELD_CODES.linkedin) || undefined,
+      instagram: getStringField(fields, FIELD_CODES.instagram) || undefined,
+      twitter: getStringField(fields, FIELD_CODES.twitter) || undefined,
+      website: getStringField(fields, FIELD_CODES.website) || undefined,
+    },
+  };
+}
+
+const CORS_HEADERS = { 'Access-Control-Allow-Origin': '*' };
+
+export async function onRequestGet(context: { request: Request; env: Env }): Promise<Response> {
+  const { env } = context;
+
+  try {
+    const cached = await env.KV.get(KV_KEY);
+    if (cached) {
+      log('gallery.cache_hit', {});
+      return new Response(cached, {
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': `public, s-maxage=${CACHE_TTL}`,
+          ...CORS_HEADERS,
+        },
+      });
+    }
+
+    const token = await getWAToken(env);
+    const params = new URLSearchParams({
+      '$filter': 'MembershipEnabled eq true',
+      '$select': 'Id,FirstName,LastName,DisplayName,MembershipLevel,MemberSince,ProfileImage,FieldValues',
+      '$top': '500',
+      '$async': 'false',
+    });
+    const res = await fetch(
+      `https://api.wildapricot.org/v2.2/accounts/${env.WILDAPRICOT_ACCOUNT_ID}/contacts?${params}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    if (!res.ok) throw new Error(`WA contacts fetch failed: ${res.status}`);
+
+    const data = await res.json() as { Contacts: WAContact[] };
+    const members = (data.Contacts ?? []).map(c => transformContact(env, c));
+
+    log('gallery.cache_miss', { count: members.length });
+
+    const body = JSON.stringify({ members, total: members.length });
+    await env.KV.put(KV_KEY, body, { expirationTtl: CACHE_TTL });
+
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': `public, s-maxage=${CACHE_TTL}`,
+        ...CORS_HEADERS,
+      },
+    });
+  } catch (err) {
+    logError('gallery.fetch_error', err, {});
+    return new Response(
+      JSON.stringify({ error: 'No se ha podido cargar el directorio. Inténtalo de nuevo.' }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...CORS_HEADERS } },
+    );
+  }
+}
+
+export async function onRequestOptions(): Promise<Response> {
+  return new Response(null, {
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    },
+  });
+}

--- a/src/hooks/useMemberFilters.ts
+++ b/src/hooks/useMemberFilters.ts
@@ -1,0 +1,117 @@
+import { useMemo, useState } from 'react';
+import type { Member } from '@/types/member';
+
+export type MemberFilters = {
+  specializations: string[];
+  locations: string[];
+  availabilityStatus: string[];
+  hasSocialMedia: boolean | null;
+  membershipTypes: string[];
+};
+
+const DEFAULT_FILTERS: MemberFilters = {
+  specializations: [],
+  locations: [],
+  availabilityStatus: [],
+  hasSocialMedia: null,
+  membershipTypes: [],
+};
+
+export function useMemberFilters(members: Member[], searchTerm: string) {
+  const [filters, setFiltersState] = useState<MemberFilters>(DEFAULT_FILTERS);
+
+  const availableLocations = useMemo(() => {
+    const locs = new Set<string>();
+    members.forEach(m => {
+      if (m.city) locs.add(m.city);
+      if (m.country) locs.add(m.country);
+    });
+    return Array.from(locs).sort();
+  }, [members]);
+
+  const memberCounts = useMemo(() => {
+    const byType: Record<string, number> = {};
+    const byAvailability: Record<string, number> = {};
+    members.forEach(m => {
+      if (m.membership_type) {
+        byType[m.membership_type] = (byType[m.membership_type] ?? 0) + 1;
+      }
+      const status = m.availability_status ?? 'Disponible';
+      byAvailability[status] = (byAvailability[status] ?? 0) + 1;
+    });
+    return { byType, byAvailability };
+  }, [members]);
+
+  const filteredMembers = useMemo(() => {
+    return members.filter(m => {
+      if (searchTerm) {
+        const q = searchTerm.toLowerCase();
+        const nameMatch = `${m.first_name} ${m.last_name}`.toLowerCase().includes(q);
+        const profMatch = (m.main_profession ?? '').toLowerCase().includes(q);
+        if (!nameMatch && !profMatch) return false;
+      }
+      if (filters.specializations.length > 0) {
+        const allProfs = [m.main_profession, ...(m.other_professions ?? [])].filter(Boolean) as string[];
+        if (!filters.specializations.some(s => allProfs.includes(s))) return false;
+      }
+      if (filters.locations.length > 0) {
+        const memberLocs = [m.city, m.country].filter(Boolean) as string[];
+        if (!filters.locations.some(l => memberLocs.includes(l))) return false;
+      }
+      if (filters.availabilityStatus.length > 0) {
+        if (!filters.availabilityStatus.includes(m.availability_status ?? '')) return false;
+      }
+      if (filters.membershipTypes.length > 0) {
+        if (!filters.membershipTypes.includes(m.membership_type ?? '')) return false;
+      }
+      if (filters.hasSocialMedia !== null) {
+        const hasSocial = Object.values(m.social_media ?? {}).some(Boolean);
+        if (filters.hasSocialMedia !== hasSocial) return false;
+      }
+      return true;
+    });
+  }, [members, filters, searchTerm]);
+
+  const activeFilterCount = useMemo(() => {
+    let count = 0;
+    count += filters.specializations.length;
+    count += filters.locations.length;
+    count += filters.availabilityStatus.length;
+    count += filters.membershipTypes.length;
+    if (filters.hasSocialMedia !== null) count++;
+    return count;
+  }, [filters]);
+
+  function setFilters(updates: Partial<MemberFilters>) {
+    setFiltersState(prev => ({ ...prev, ...updates }));
+  }
+
+  function resetFilters() {
+    setFiltersState(DEFAULT_FILTERS);
+  }
+
+  function toggle(
+    key: keyof Pick<MemberFilters, 'specializations' | 'locations' | 'availabilityStatus' | 'membershipTypes'>,
+    value: string,
+  ) {
+    setFiltersState(prev => {
+      const arr = prev[key];
+      const next = arr.includes(value) ? arr.filter(v => v !== value) : [...arr, value];
+      return { ...prev, [key]: next };
+    });
+  }
+
+  return {
+    filters,
+    setFilters,
+    resetFilters,
+    filteredMembers,
+    activeFilterCount,
+    availableLocations,
+    memberCounts,
+    toggleSpecialization: (s: string) => toggle('specializations', s),
+    toggleLocation: (l: string) => toggle('locations', l),
+    toggleAvailabilityStatus: (s: string) => toggle('availabilityStatus', s),
+    toggleMembershipType: (t: string) => toggle('membershipTypes', t),
+  };
+}

--- a/src/pages/SociasPage.tsx
+++ b/src/pages/SociasPage.tsx
@@ -1,18 +1,46 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { BackgroundImage } from '@/components/ui/background-image';
+import type { Member } from '@/types/member';
+import { useMemberFilters } from '@/hooks/useMemberFilters';
+import { MemberCard } from './socias/MemberCard';
+import { MemberFilters } from './socias/MemberFilters';
+import { MemberModal } from './socias/MemberModal';
 
-/**
- * SociasPage - Member Directory
- *
- * Displays a "Coming Soon" placeholder for the full member directory.
- * Users can browse Founders and Board Members in the meantime.
- *
- * Future enhancement: Implement member search and filtering
- * See FundadorasPage.tsx for similar member display pattern
- */
+async function fetchMembers(): Promise<Member[]> {
+  const res = await fetch('/api/members');
+  if (!res.ok) throw new Error(`Error ${res.status}`);
+  const data = await res.json() as { members: Member[] };
+  return data.members ?? [];
+}
+
 export function SociasPage() {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedMember, setSelectedMember] = useState<Member | null>(null);
+
+  const { data: members = [], isLoading, isError, refetch } = useQuery({
+    queryKey: ['gallery-members'],
+    queryFn: fetchMembers,
+    staleTime: 60 * 60 * 1000, // 1h — mirrors KV TTL
+  });
+
+  const {
+    filters,
+    setFilters,
+    resetFilters,
+    filteredMembers,
+    activeFilterCount,
+    availableLocations,
+    memberCounts,
+    toggleSpecialization,
+    toggleLocation,
+    toggleAvailabilityStatus,
+    toggleMembershipType,
+  } = useMemberFilters(members, searchTerm);
+
   return (
     <div className="min-h-screen bg-gray-900">
-      {/* Hero Section */}
+      {/* Hero */}
       <BackgroundImage
         imageUrl="/images/home-cta.webp"
         className="w-full py-16 px-4 sm:px-6 lg:px-8"
@@ -24,95 +52,96 @@ export function SociasPage() {
           <p className="text-lg md:text-xl text-gray-200 mb-8 max-w-3xl mx-auto">
             Directorio de socias profesionales de la animación en España.
           </p>
+          <div className="max-w-xl mx-auto">
+            <input
+              type="search"
+              value={searchTerm}
+              onChange={e => setSearchTerm(e.target.value)}
+              placeholder="Buscar por nombre o profesión..."
+              className="w-full px-4 py-3 rounded-lg bg-gray-800/80 text-white placeholder-gray-400 border border-gray-600 focus:outline-none focus:border-red-500"
+            />
+          </div>
         </div>
       </BackgroundImage>
 
-      {/* Coming Soon Content */}
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-        <div className="text-center">
-          <div className="mb-8">
-            <svg
-              className="mx-auto h-24 w-24 text-red-500"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={1.5}
-                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-              />
-            </svg>
-          </div>
+      {/* Filters */}
+      <MemberFilters
+        filters={filters}
+        availableLocations={availableLocations}
+        memberCounts={memberCounts}
+        toggleMembershipType={toggleMembershipType}
+        toggleSpecialization={toggleSpecialization}
+        toggleLocation={toggleLocation}
+        toggleAvailabilityStatus={toggleAvailabilityStatus}
+        setFilters={setFilters}
+      />
 
-          <h2 className="text-3xl font-bold text-white mb-4">
-            Próximamente
-          </h2>
-
-          <p className="text-xl text-gray-300 mb-8">
-            El directorio de socias estará disponible próximamente.
-          </p>
-
-          <div className="bg-gray-800 rounded-lg p-8 text-left max-w-2xl mx-auto">
-            <h3 className="text-lg font-semibold text-white mb-4">
-              ¿Qué encontrarás en esta sección?
-            </h3>
-            <ul className="space-y-3 text-gray-300">
-              <li className="flex items-start">
-                <svg className="h-6 w-6 text-red-500 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                <span>Directorio completo de socias profesionales</span>
-              </li>
-              <li className="flex items-start">
-                <svg className="h-6 w-6 text-red-500 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                <span>Búsqueda por nombre, especialización y ubicación</span>
-              </li>
-              <li className="flex items-start">
-                <svg className="h-6 w-6 text-red-500 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                <span>Filtros por tipo de membresía y estado de disponibilidad</span>
-              </li>
-              <li className="flex items-start">
-                <svg className="h-6 w-6 text-red-500 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                <span>Perfiles detallados con información profesional y contacto</span>
-              </li>
-            </ul>
-          </div>
-
-          <div className="mt-12">
-            <p className="text-gray-400 mb-4">
-              Mientras tanto, puedes conocer más sobre nosotras:
+      {/* Gallery */}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {!isLoading && !isError && (
+          <div className="flex items-center justify-between mb-6">
+            <p className="text-gray-400 text-sm">
+              {filteredMembers.length === members.length
+                ? `${members.length} socias`
+                : `${filteredMembers.length} de ${members.length} socias`}
             </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <a
-                href="/fundadoras"
-                className="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-red-600 hover:bg-red-700 transition-colors duration-200"
+            {activeFilterCount > 0 && (
+              <button
+                onClick={resetFilters}
+                className="text-sm text-red-400 hover:text-red-300 transition-colors"
               >
-                Ver Fundadoras
-              </a>
-              <a
-                href="/directiva"
-                className="inline-flex items-center justify-center px-6 py-3 border border-gray-600 text-base font-medium rounded-md text-white hover:bg-gray-800 transition-colors duration-200"
-              >
-                Ver Directiva
-              </a>
-              <a
-                href="/sobre-mia"
-                className="inline-flex items-center justify-center px-6 py-3 border border-gray-600 text-base font-medium rounded-md text-white hover:bg-gray-800 transition-colors duration-200"
-              >
-                Sobre MIA
-              </a>
-            </div>
+                Limpiar filtros ({activeFilterCount})
+              </button>
+            )}
           </div>
-        </div>
+        )}
+
+        {isLoading && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {Array.from({ length: 12 }).map((_, i) => (
+              <div key={i} className="bg-gray-800 rounded-lg h-48 animate-pulse" />
+            ))}
+          </div>
+        )}
+
+        {isError && (
+          <div className="text-center py-16">
+            <p className="text-gray-300 mb-4">No se ha podido cargar el directorio.</p>
+            <button
+              onClick={() => void refetch()}
+              className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-md text-sm transition-colors"
+            >
+              Reintentar
+            </button>
+          </div>
+        )}
+
+        {!isLoading && !isError && filteredMembers.length === 0 && (
+          <div className="text-center py-16">
+            <p className="text-gray-400">No se han encontrado socias con esos filtros.</p>
+          </div>
+        )}
+
+        {!isLoading && !isError && filteredMembers.length > 0 && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {filteredMembers.map(member => (
+              <MemberCard
+                key={member.id}
+                member={member}
+                onClick={() => setSelectedMember(member)}
+              />
+            ))}
+          </div>
+        )}
       </div>
+
+      {selectedMember && (
+        <MemberModal
+          member={selectedMember}
+          isOpen
+          onClose={() => setSelectedMember(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/socias/MemberFilters.tsx
+++ b/src/pages/socias/MemberFilters.tsx
@@ -29,8 +29,7 @@ export function MemberFilters({
 }: MemberFiltersProps) {
   return (
     <div className="bg-gray-800 border-b border-gray-700">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-        {/* Filter Tabs */}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
         <Tabs defaultValue="specialization" className="w-full">
           <TabsList className="w-full grid grid-cols-4 bg-gray-700 p-1 rounded-lg">
             <TabsTrigger value="specialization" className="text-xs sm:text-sm">
@@ -67,131 +66,98 @@ export function MemberFilters({
             </TabsTrigger>
           </TabsList>
 
-          {/* Filter Content */}
-          <div className="mt-6">
+          <div className="mt-2">
             <TabsContent value="specialization">
-              <div>
-                <h3 className="text-sm font-medium text-gray-200 mb-3">Especializaciones</h3>
-                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2 max-h-80 overflow-y-auto">
-                  {ANIMATION_SPECIALIZATIONS.map((specialization) => (
-                    <label key={specialization} className="flex items-center space-x-3 p-2 rounded-lg hover:bg-gray-700 cursor-pointer">
-                      <Checkbox
-                        checked={filters.specializations.includes(specialization)}
-                        onCheckedChange={() => toggleSpecialization(specialization)}
-                        className="text-primary-500 focus:ring-primary-500"
-                      />
-                      <span className="text-sm text-gray-300 truncate">
-                        {specialization}
-                      </span>
-                    </label>
-                  ))}
-                </div>
+              <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-x-2 gap-y-0 max-h-40 overflow-y-auto">
+                {ANIMATION_SPECIALIZATIONS.map((specialization) => (
+                  <label key={specialization} className="flex items-center gap-1.5 py-0.5 px-1 rounded hover:bg-gray-700 cursor-pointer">
+                    <Checkbox
+                      checked={filters.specializations.includes(specialization)}
+                      onCheckedChange={() => toggleSpecialization(specialization)}
+                      className="text-primary-500 focus:ring-primary-500 shrink-0"
+                    />
+                    <span className="text-xs text-gray-300 truncate">{specialization}</span>
+                  </label>
+                ))}
               </div>
             </TabsContent>
 
             <TabsContent value="location">
-              <div>
-                <h3 className="text-sm font-medium text-gray-200 mb-3">Ubicación</h3>
-                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2 max-h-60 overflow-y-auto">
-                  {availableLocations.map((location) => (
-                    <label key={location} className="flex items-center space-x-3 p-2 rounded-lg hover:bg-gray-700 cursor-pointer">
-                      <Checkbox
-                        checked={filters.locations.includes(location)}
-                        onCheckedChange={() => toggleLocation(location)}
-                        className="text-primary-500 focus:ring-primary-500"
-                      />
-                      <span className="text-sm text-gray-300 truncate">
-                        {location}
-                      </span>
-                    </label>
-                  ))}
-                </div>
+              <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-x-2 gap-y-0 max-h-40 overflow-y-auto">
+                {availableLocations.map((location) => (
+                  <label key={location} className="flex items-center gap-1.5 py-0.5 px-1 rounded hover:bg-gray-700 cursor-pointer">
+                    <Checkbox
+                      checked={filters.locations.includes(location)}
+                      onCheckedChange={() => toggleLocation(location)}
+                      className="text-primary-500 focus:ring-primary-500 shrink-0"
+                    />
+                    <span className="text-xs text-gray-300 truncate">{location}</span>
+                  </label>
+                ))}
               </div>
             </TabsContent>
 
             <TabsContent value="availability">
-              <div>
-                <h3 className="text-sm font-medium text-gray-200 mb-3">Estado de Disponibilidad</h3>
-                <div className="space-y-2">
-                  {(['Disponible', 'Empleada', 'Freelance'] as const).map((status) => (
-                    <label key={status} className="flex items-center space-x-3 p-2 rounded-lg hover:bg-gray-700 cursor-pointer">
-                      <Checkbox
-                        checked={filters.availabilityStatus.includes(status)}
-                        onCheckedChange={() => toggleAvailabilityStatus(status)}
-                        className="text-primary-500 focus:ring-primary-500"
-                      />
-                      <span className="text-sm text-gray-300">
-                        {status}
-                        <span className="ml-2 text-gray-400">
-                          ({memberCounts.byAvailability[status] || 0})
-                        </span>
-                      </span>
-                    </label>
-                  ))}
-                </div>
+              <div className="flex flex-wrap gap-x-6 gap-y-0">
+                {(['Disponible', 'Empleada', 'Freelance'] as const).map((status) => (
+                  <label key={status} className="flex items-center gap-1.5 py-0.5 px-1 rounded hover:bg-gray-700 cursor-pointer">
+                    <Checkbox
+                      checked={filters.availabilityStatus.includes(status)}
+                      onCheckedChange={() => toggleAvailabilityStatus(status)}
+                      className="text-primary-500 focus:ring-primary-500 shrink-0"
+                    />
+                    <span className="text-xs text-gray-300">
+                      {status}
+                      <span className="ml-1 text-gray-500">({memberCounts.byAvailability[status] || 0})</span>
+                    </span>
+                  </label>
+                ))}
               </div>
             </TabsContent>
 
             <TabsContent value="other">
-              <div className="space-y-4">
+              <div className="flex flex-wrap gap-x-8 gap-y-2">
                 <div>
-                  <h3 className="text-sm font-medium text-gray-200 mb-3">Tipo de membresía</h3>
-                  <div className="space-y-2">
+                  <p className="text-xs text-gray-400 mb-1">Membresía</p>
+                  <div className="flex flex-wrap gap-x-4 gap-y-0">
                     {([
-                      { value: 'pleno_derecho', label: 'Socia pleno derecho' },
-                      { value: 'estudiante', label: 'Socia estudiante' },
-                      { value: 'colaborador', label: 'Socio colaborador' }
+                      { value: 'pleno_derecho', label: 'Pleno derecho' },
+                      { value: 'estudiante', label: 'Estudiante' },
+                      { value: 'colaborador', label: 'Colaborador' },
                     ] as const).map(({ value, label }) => (
-                      <label key={value} className="flex items-center space-x-3 p-2 rounded-lg hover:bg-gray-700 cursor-pointer">
+                      <label key={value} className="flex items-center gap-1.5 py-0.5 px-1 rounded hover:bg-gray-700 cursor-pointer">
                         <Checkbox
                           checked={filters.membershipTypes.includes(value)}
                           onCheckedChange={() => toggleMembershipType(value)}
-                          className="text-primary-500 focus:ring-primary-500"
+                          className="text-primary-500 focus:ring-primary-500 shrink-0"
                         />
-                        <span className="text-sm text-gray-300">
+                        <span className="text-xs text-gray-300">
                           {label}
-                          <span className="ml-2 text-gray-400">
-                            ({memberCounts.byType[value] || 0})
-                          </span>
+                          <span className="ml-1 text-gray-500">({memberCounts.byType[value] || 0})</span>
                         </span>
                       </label>
                     ))}
                   </div>
                 </div>
-
                 <div>
-                  <h3 className="text-sm font-medium text-gray-200 mb-3">Presencia en Redes Sociales</h3>
-                  <div className="space-y-2">
-                    <label className="flex items-center space-x-3 p-2 rounded-lg hover:bg-gray-700 cursor-pointer">
-                      <input
-                        type="radio"
-                        name="socialMedia"
-                        checked={filters.hasSocialMedia === true}
-                        onChange={() => setFilters({ hasSocialMedia: true })}
-                        className="h-4 w-4 text-primary-500 focus:ring-primary-500 border-gray-600"
-                      />
-                      <span className="text-sm text-gray-300">Con redes sociales</span>
-                    </label>
-                    <label className="flex items-center space-x-3 p-2 rounded-lg hover:bg-gray-700 cursor-pointer">
-                      <input
-                        type="radio"
-                        name="socialMedia"
-                        checked={filters.hasSocialMedia === false}
-                        onChange={() => setFilters({ hasSocialMedia: false })}
-                        className="h-4 w-4 text-primary-500 focus:ring-primary-500 border-gray-600"
-                      />
-                      <span className="text-sm text-gray-300">Sin redes sociales</span>
-                    </label>
-                    <label className="flex items-center space-x-3 p-2 rounded-lg hover:bg-gray-700 cursor-pointer">
-                      <input
-                        type="radio"
-                        name="socialMedia"
-                        checked={filters.hasSocialMedia === null}
-                        onChange={() => setFilters({ hasSocialMedia: null })}
-                        className="h-4 w-4 text-primary-500 focus:ring-primary-500 border-gray-600"
-                      />
-                      <span className="text-sm text-gray-300">Todos</span>
-                    </label>
+                  <p className="text-xs text-gray-400 mb-1">Redes sociales</p>
+                  <div className="flex flex-wrap gap-x-4 gap-y-0">
+                    {([
+                      { value: true, label: 'Con redes' },
+                      { value: false, label: 'Sin redes' },
+                      { value: null, label: 'Todas' },
+                    ] as const).map(({ value, label }) => (
+                      <label key={label} className="flex items-center gap-1.5 py-0.5 px-1 rounded hover:bg-gray-700 cursor-pointer">
+                        <input
+                          type="radio"
+                          name="socialMedia"
+                          checked={filters.hasSocialMedia === value}
+                          onChange={() => setFilters({ hasSocialMedia: value })}
+                          className="h-3.5 w-3.5 text-primary-500 focus:ring-primary-500 border-gray-600"
+                        />
+                        <span className="text-xs text-gray-300">{label}</span>
+                      </label>
+                    ))}
                   </div>
                 </div>
               </div>

--- a/src/pages/socias/MemberFilters.tsx
+++ b/src/pages/socias/MemberFilters.tsx
@@ -83,18 +83,22 @@ export function MemberFilters({
             </TabsContent>
 
             <TabsContent value="location">
-              <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-x-2 gap-y-0 max-h-40 overflow-y-auto">
-                {availableLocations.map((location) => (
-                  <label key={location} className="flex items-center gap-1.5 py-0.5 px-1 rounded hover:bg-gray-700 cursor-pointer">
-                    <Checkbox
-                      checked={filters.locations.includes(location)}
-                      onCheckedChange={() => toggleLocation(location)}
-                      className="text-primary-500 focus:ring-primary-500 shrink-0"
-                    />
-                    <span className="text-xs text-gray-300 truncate">{location}</span>
-                  </label>
-                ))}
-              </div>
+              {availableLocations.length === 0 ? (
+                <p className="text-xs text-gray-500 py-1">Las ubicaciones se cargan con los datos de socias.</p>
+              ) : (
+                <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-x-2 gap-y-0 max-h-40 overflow-y-auto">
+                  {availableLocations.map((location) => (
+                    <label key={location} className="flex items-center gap-1.5 py-0.5 px-1 rounded hover:bg-gray-700 cursor-pointer">
+                      <Checkbox
+                        checked={filters.locations.includes(location)}
+                        onCheckedChange={() => toggleLocation(location)}
+                        className="text-primary-500 focus:ring-primary-500 shrink-0"
+                      />
+                      <span className="text-xs text-gray-300 truncate">{location}</span>
+                    </label>
+                  ))}
+                </div>
+              )}
             </TabsContent>
 
             <TabsContent value="availability">


### PR DESCRIPTION
## Summary

- **`GET /api/members`** — fetches active WildApricot contacts, transforms to `Member` shape, caches in KV (`gallery_members` key) for 1 hour
- **`useMemberFilters` hook** — filter state + toggle helpers + client-side filtering (search, specialization, location, availability, membership type, social media presence)
- **`SociasPage`** — replaces "Próximamente" placeholder with a real gallery: search input, filter panel, responsive 3-col grid of `MemberCard`, loading skeleton, error/retry, `MemberModal` on click

## Architecture decisions

- **No D1** — KV is sufficient for ~400 members as a single JSON blob (~800 KB), with 1h TTL matching admin-controlled update frequency
- **No library** — `MemberCard`, `MemberModal`, `MemberFilters` sub-components already existed; just needed wiring
- **Client-side filtering** — instant at 400 records, no server round-trips per filter

## Test plan

- [ ] `npm run build` passes (TypeScript + Vite) ✅
- [ ] `npm run lint` passes ✅
- [ ] `npx wrangler pages dev --proxy 3000 --port 8788` → navigate to `/socias` → gallery loads from `/api/members`
- [ ] Search by name narrows results
- [ ] Filter by specialization updates count
- [ ] Click a card → modal opens with full profile
- [ ] "Limpiar filtros" resets all filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)