### PR TITLE
feat(gallery): deploy member gallery (align modal + type with members API)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,11 @@ DEPLOYMENT.md
 # Application Data & Backups
 members_data/
 wildapricot-migration/
+# Member data exports (personal data — NEVER commit)
+*.csv
+*.xlsx
+*.xls
+MIA_*.*
 db-backups/
 
 # Temporary files

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.62.0",
-        "react-router-dom": "^7.13.2",
+        "react-router-dom": "^7.18.0",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.2.2",
         "vanilla-cookieconsent": "^3.1.0",
@@ -9656,9 +9656,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
-      "integrity": "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
+      "integrity": "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -9678,12 +9678,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.2.tgz",
-      "integrity": "sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.0.tgz",
+      "integrity": "sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.2"
+        "react-router": "7.18.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.62.0",
-    "react-router-dom": "^7.13.2",
+    "react-router-dom": "^7.18.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.2.2",
     "vanilla-cookieconsent": "^3.1.0",

--- a/src/pages/socias/MemberCard.tsx
+++ b/src/pages/socias/MemberCard.tsx
@@ -6,12 +6,12 @@ import type { Member } from '@/types/member';
 import { memo } from 'react';
 
 interface MemberCardProps {
-  member: Member & { is_founder?: boolean };
+  member: Member;
   onClick: () => void;
 }
 
 const MemberCardComponent = ({ member, onClick }: MemberCardProps) => {
-  const displayProfession = member.main_profession || member.company || 'Profesional';
+  const displayProfession = member.main_profession || 'Profesional';
   const rawSpecializations = member.other_professions || [];
   const specializationChips =
     rawSpecializations.length > 0

--- a/src/pages/socias/MemberModal.tsx
+++ b/src/pages/socias/MemberModal.tsx
@@ -1,7 +1,6 @@
 import { ProfileImage } from '@/components/ProfileImage';
 import { SocialMediaIcons } from '@/components/SocialMediaIcons';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import type { Member } from '@/types/member';
 
@@ -13,7 +12,7 @@ interface MemberModalProps {
 
 export function MemberModal({ member, isOpen, onClose }: MemberModalProps) {
   const availabilityStatus = member.availability_status || 'Disponible';
-  const isFounder = (member as Member & { is_founder?: boolean }).is_founder === true;
+  const isFounder = member.is_founder === true;
 
   const membershipLabel =
     member.membership_type === 'pleno_derecho'
@@ -45,9 +44,6 @@ export function MemberModal({ member, isOpen, onClose }: MemberModalProps) {
                 {member.main_profession && (
                   <span className="block font-medium">{member.main_profession}</span>
                 )}
-                {member.company && (
-                  <span className="block">{member.company}</span>
-                )}
                 <span className="block text-sm text-gray-400 mt-1">
                   {membershipLabel}
                   {member.created_at && ` • Socia desde ${new Date(member.created_at).getFullYear()}`}
@@ -73,14 +69,6 @@ export function MemberModal({ member, isOpen, onClose }: MemberModalProps) {
                     <span>{availabilityStatus}</span>
                   </span>
                 </Badge>
-                {member.accepts_job_offers && (
-                  <Badge variant="outline" className="border-green-500 text-green-400">
-                    <span className="flex items-center space-x-1">
-                      <span>💼</span>
-                      <span>Acepta ofertas laborales</span>
-                    </span>
-                  </Badge>
-                )}
               </div>
             </div>
           </div>
@@ -113,18 +101,6 @@ export function MemberModal({ member, isOpen, onClose }: MemberModalProps) {
                   <p className="text-gray-100">{member.other_professions.join(', ')}</p>
                 </div>
               )}
-              {member.professional_role && (
-                <div>
-                  <span className="text-gray-400">Rol profesional:</span>
-                  <p className="text-gray-100">{member.professional_role}</p>
-                </div>
-              )}
-              {member.years_experience && (
-                <div>
-                  <span className="text-gray-400">Años de experiencia:</span>
-                  <p className="text-gray-100">{member.years_experience} años</p>
-                </div>
-              )}
             </div>
           </div>
 
@@ -132,45 +108,17 @@ export function MemberModal({ member, isOpen, onClose }: MemberModalProps) {
           <div>
             <h4 className="text-sm font-medium text-gray-200 mb-2">Ubicación</h4>
             <div className="text-sm text-gray-300 space-y-1">
-              {member.province && (
-                <p className="flex items-center">
-                  <span className="text-gray-500 mr-2">🌍</span>
-                  {member.province}
-                  {member.autonomous_community && `, ${member.autonomous_community}`}
-                </p>
-              )}
               <p className="flex items-center">
-                <span className="text-gray-500 mr-2">🇪🇸</span>
+                <span className="text-gray-500 mr-2">🌍</span>
                 {member.country || 'España'}
               </p>
             </div>
           </div>
 
-          {/* CV Download */}
-          {member.cv_document_url && (
-            <div>
-              <Button
-                onClick={() => window.open(member.cv_document_url!, '_blank')}
-                className="w-full sm:w-auto bg-primary-600 hover:bg-primary-700 text-white"
-              >
-                <svg className="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                </svg>
-                Descargar CV
-              </Button>
-            </div>
-          )}
-
           {/* Contact & Social Media */}
           <div>
             <h4 className="text-sm font-medium text-gray-200 mb-3">Contacto y Redes Sociales</h4>
             <div className="space-y-3">
-              {member.phone && (
-                <div className="flex items-center text-sm">
-                  <span className="text-gray-500 mr-2">📞</span>
-                  <span className="text-gray-300">{member.phone}</span>
-                </div>
-              )}
               <div>
                 <SocialMediaIcons
                   socialMedia={member.social_media || {}}

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -1,58 +1,29 @@
 // Standalone type definitions for members and board positions
 // No Supabase dependencies
 
+// Gallery member — mirrors the /api/members response shape (WildApricot → JSON).
+// Keep this in sync with transformContact() in functions/api/members.ts.
 export interface Member {
   id: string;
-  email: string;
   first_name: string;
   last_name: string;
   display_name?: string;
-  member_number?: string;
-  phone?: string;
-  address: string;
-  city: string;
-  postal_code?: string;
-  province?: string;
-  autonomous_community?: string;
-  country: string;
+  profile_image_url?: string;
+  biography?: string;
   main_profession?: string;
   other_professions?: string[];
-  professional_role?: string;
-  company?: string;
-  years_experience?: number;
-  biography?: string;
-  employment_status?: string;
   availability_status?: string;
-  education_level?: string;
-  studies_completed?: string;
-  educational_institution?: string;
-  is_student?: boolean;
+  city?: string;
+  country?: string;
   membership_type: string;
-  is_board_member?: boolean;
-  board_position?: BoardPosition;
-  board_term_start?: string;
-  board_term_end?: string;
-  board_personal_commitment?: string;
-  accepts_newsletter?: boolean;
-  accepts_job_offers?: boolean;
-  privacy_level?: 'public' | 'members-only' | 'private';
-  gdpr_accepted?: boolean;
+  created_at?: string;
   social_media?: {
     linkedin?: string;
     instagram?: string;
     twitter?: string;
-    facebook?: string;
     website?: string;
-    youtube?: string;
-    vimeo?: string;
-    artstation?: string;
   };
-  profile_image_url?: string;
-  cv_document_url?: string;
-  birth_date?: string;
-  other_associations?: string[];
-  created_at?: string;
-  updated_at?: string;
+  is_founder?: boolean;
 }
 
 // Board position types - all positions for women-only organization


### PR DESCRIPTION
## What

Unblocks and deploys the **Socias member gallery** on the React site. The gallery was already ~90% built (page, cards, filters, search, `/api/members` endpoint with KV caching, routing, nav) — this closes the two frontend gaps that prevented shipping.

## Changes

- **`src/types/member.ts`** — narrow the gallery `Member` type to exactly the `/api/members` response shape (it was over-declaring ~40 fields). Used only by the 4 gallery files, so no collateral impact.
- **`src/pages/socias/MemberModal.tsx`** — remove sections that read fields the API never returns (`company`, `accepts_job_offers` badge, `professional_role`, `years_experience`, `province`/`autonomous_community`, CV download, `phone`) plus the unused `Button` import and a type cast.
- **`src/pages/socias/MemberCard.tsx`** — drop the `member.company` fallback and redundant type intersection.

No backend change — `/api/members` already returns all active members (decision: show all, no opt-in filter).

## Verification

- `npm run build` ✅ · `npm run lint` ✅ · `npm test` ✅ (111 passing)
- Local browser check on `/socias` with mocked data: cards render, filters/search intact, modal opens with only supported sections (no empty fields), no console errors.
- ⚠️ Full live-data verification happens on the `dev` Cloudflare deploy (real `WILDAPRICOT_API_KEY` secret) — confirm member count/cards there before promoting to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)