### PR TITLE
fix(members): paginate WildApricot contacts ($skip) for mandatory API pagination

### DIFF
--- a/functions/api/members.ts
+++ b/functions/api/members.ts
@@ -108,20 +108,34 @@ export async function onRequestGet(context: { request: Request; env: Env }): Pro
     }
 
     const token = await getWAToken(env);
-    const params = new URLSearchParams({
-      '$filter': 'MembershipEnabled eq true',
-      '$select': 'Id,FirstName,LastName,DisplayName,MembershipLevel,MemberSince,ProfileImage,FieldValues',
-      '$top': '500',
-      '$async': 'false',
-    });
-    const res = await fetch(
-      `https://api.wildapricot.org/v2.2/accounts/${env.WILDAPRICOT_ACCOUNT_ID}/contacts?${params}`,
-      { headers: { Authorization: `Bearer ${token}` } },
-    );
-    if (!res.ok) throw new Error(`WA contacts fetch failed: ${res.status}`);
 
-    const data = await res.json() as { Contacts: WAContact[] };
-    const members = (data.Contacts ?? []).map(c => transformContact(env, c));
+    // WildApricot enforces pagination on Contacts since 2025-11-01: $top is capped
+    // at 100 and full lists require iterating with $skip. Page until a short page.
+    // https://gethelp.wildapricot.com/en/articles/2911-updating-your-api-integrations-for-pagination
+    const PAGE_SIZE = 100;
+    const MAX_PAGES = 50; // safety cap (≤5000 members) to avoid an unbounded loop
+    const contacts: WAContact[] = [];
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const params = new URLSearchParams({
+        '$filter': 'MembershipEnabled eq true',
+        '$select': 'Id,FirstName,LastName,DisplayName,MembershipLevel,MemberSince,ProfileImage,FieldValues',
+        '$top': String(PAGE_SIZE),
+        '$skip': String(page * PAGE_SIZE),
+        '$async': 'false',
+      });
+      const res = await fetch(
+        `https://api.wildapricot.org/v2.2/accounts/${env.WILDAPRICOT_ACCOUNT_ID}/contacts?${params}`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+      if (!res.ok) throw new Error(`WA contacts fetch failed: ${res.status}`);
+
+      const data = await res.json() as { Contacts: WAContact[] };
+      const batch = data.Contacts ?? [];
+      contacts.push(...batch);
+      if (batch.length < PAGE_SIZE) break; // last page reached
+    }
+
+    const members = contacts.map(c => transformContact(env, c));
 
     log('gallery.cache_miss', { count: members.length });
 


### PR DESCRIPTION
## Why

WildApricot made API **pagination mandatory on 2025-11-01** ([docs](https://gethelp.wildapricot.com/en/articles/2911-updating-your-api-integrations-for-pagination)). The Contacts admin endpoint now caps `$top` at 100, and full lists must be retrieved by iterating `$skip`.

`functions/api/members.ts` requested `$top=500` with a `$filter` and no `$skip`, which:
- at best returned only the first **100** of ~315 members (silent truncation), and
- at worst is the cause of the current **`/api/members` 500** (if WA rejects `$top>100` on this endpoint, our code throws).

## Change

Loop the Contacts call with `$top=100` + `$skip`, accumulating pages until a short page (<100) signals the end. Safety cap of 50 pages (≤5000 members). No change to the response shape, filtering, or KV cache.

## Verification

- `tsc --noEmit` ✅ · `npm run lint` ✅ (the endpoint can't be exercised locally — needs the live `WILDAPRICOT_API_KEY` secret; verify on the dev deploy).
- After merge → dev deploy: `GET https://dev.animacionesmia.com/api/members` should return HTTP 200 with `total` ≈ full member count (not capped at 100).

⚠️ Note: if the 500 was actually the rotated API key not being set on the Cloudflare **Preview** environment, that still needs fixing separately — this PR fixes the (independent, real) pagination bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)