### PR TITLE
chore(cleanup): drop dead types, unused zustand dep, and duplicate log

### DIFF
--- a/functions/api/members.ts
+++ b/functions/api/members.ts
@@ -163,8 +163,6 @@ export async function onRequestGet(context: { request: Request; env: Env }): Pro
 
     log('gallery.cache_miss', { count: members.length });
 
-    log('gallery.cache_miss', { count: members.length });
-
     const body = JSON.stringify({ members, total: members.length });
     await env.KV.put(KV_KEY, body, { expirationTtl: CACHE_TTL });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,8 +34,7 @@
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.2.2",
         "vanilla-cookieconsent": "^3.1.0",
-        "zod": "^4.0.14",
-        "zustand": "^5.0.14"
+        "zod": "^4.0.14"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -11951,35 +11950,6 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
-      }
-    },
-    "node_modules/zustand": {
-      "version": "5.0.14",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
-      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=18.0.0",
-        "immer": ">=9.0.6",
-        "react": ">=18.0.0",
-        "use-sync-external-store": ">=1.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "use-sync-external-store": {
-          "optional": true
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.2.2",
     "vanilla-cookieconsent": "^3.1.0",
-    "zod": "^4.0.14",
-    "zustand": "^5.0.14"
+    "zod": "^4.0.14"
   },
   "overrides": {
     "serialize-javascript": ">=7.0.3"

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,5 +1,5 @@
-import type { Member, FormData, ContactFormData } from './index';
-import type { BoardMember } from './member';
+import type { FormData, ContactFormData } from './index';
+import type { Member, BoardMember } from './member';
 
 // API Response interfaces
 export interface ApiResponse<T = unknown> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,54 +30,9 @@ export interface ApiResponse<T = unknown> {
   error?: string;
 }
 
-// Gallery and Member types
-export interface Member {
-  id: string;
-  firstName: string;
-  lastName: string;
-  displayName?: string;
-  email: string;
-  company?: string;
-  location: {
-    city?: string;
-    region?: string;
-    country: string;
-  };
-  memberType: 'socia-pleno-derecho' | 'colaborador';
-  membershipType?: string;
-  specializations: string[];
-  availabilityStatus: 'Disponible' | 'Empleada' | 'Freelance';
-  socialMedia: {
-    linkedin?: string;
-    twitter?: string;
-    instagram?: string;
-    website?: string;
-  };
-  profileImage?: string;
-  bio?: string;
-  joinDate: string;
-  isActive: boolean;
-  status?: 'active' | 'pending' | 'expired';
-  membershipStatus?: 'active' | 'pending' | 'expired';
-}
-
-export interface FilterState {
-  memberTypes: ('socia-pleno-derecho' | 'colaborador')[];
-  specializations: string[];
-  locations: string[];
-  availabilityStatus: ('Disponible' | 'Empleada' | 'Freelance')[];
-  hasSocialMedia: boolean | null;
-  isActive: boolean | null;
-}
-
-export interface GalleryState {
-  members: Member[];
-  filters: FilterState;
-  searchTerm: string;
-  loading: boolean;
-  selectedMember: Member | null;
-  isModalOpen: boolean;
-}
+// NOTE: The gallery Member type lives in `@/types/member` — import it from there.
+// The previous duplicate definition here (and the unused FilterState/GalleryState)
+// were removed; the live gallery uses the WildApricot-shaped Member in member.ts.
 
 // Animation profession categories constants
 export const ANIMATION_SPECIALIZATIONS = [


### PR DESCRIPTION
## What

Mechanical cleanup of debt surfaced during the design review.

- **Duplicate `Member` type** — removed the stale definition (plus unused `FilterState`/`GalleryState`) from `src/types/index.ts`. The live gallery uses the WildApricot-shaped `Member` in `src/types/member.ts`. Repointed `src/types/api.ts` to import the canonical one (it was silently using the wrong shape).
- **Unused `zustand` dependency** — installed but no store was ever created. Removed.
- **Duplicate log** — `functions/api/members.ts` emitted `gallery.cache_miss` twice on every cache miss.

## Verification
- `npm run build` ✓
- `npm run lint` ✓ (0 errors)
- `npm test` ✓ (111 passed)

No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)