### PR TITLE
refactor(styles): consolidate color tokens into a single @theme source

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,36 +2,89 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap');
 @import "tailwindcss";
 
-/* CSS Custom Properties for MIA Design System - WordPress Match */
-:root {
-  /* WordPress Exact Colors */
-  --color-primary: #d8242e;
-  --color-primary-hover: #b01f28;
-  --color-primary-light: #FE2828;
-  
-  /* Header Colors (Light) */
-  --color-header-bg: #ffffff;
-  --color-header-text: #333333;
-  --color-header-border: #d2d2d2;
-  
-  /* Footer Colors (Black) */
-  --color-footer-bg: #000000;
-  --color-footer-text: #ffffff;
-  --color-footer-link-hover: #FE2828;
-  
-  /* Content Colors */
+/* ============================================================
+   MIA Design Tokens — single source of truth (Tailwind v4 @theme)
+
+   Brand red is anchored at primary-600 (#d8242e, the WordPress brand
+   color). Tailwind's `red-*` scale AND the `primary-*` scale are aliased
+   to the same ramp, so brand red is byte-identical whether a component
+   uses `bg-red-600`, `bg-primary-600`, or `bg-primary`. shadcn semantic
+   tokens (consumed by src/components/ui/*) point at the same source.
+   ============================================================ */
+@theme {
+  /* Brand red ramp */
+  --color-primary-50:  #fef2f3;
+  --color-primary-100: #fde0e2;
+  --color-primary-200: #fac4c8;
+  --color-primary-300: #f59aa0;
+  --color-primary-400: #ec6169;
+  --color-primary-500: #e03742;
+  --color-primary-600: #d8242e; /* brand */
+  --color-primary-700: #b01f28; /* brand hover */
+  --color-primary-800: #8f1a21;
+  --color-primary-900: #761a20;
+  --color-primary-950: #41090d;
+
+  /* Single brand token: bg-primary / text-primary / var(--color-primary) */
+  --color-primary: var(--color-primary-600);
+  --color-primary-hover: var(--color-primary-700);
+  --color-primary-light: var(--color-primary-400);
+  --color-primary-foreground: #ffffff;
+
+  /* Align Tailwind's red-* scale to the brand ramp — one red everywhere */
+  --color-red-50:  var(--color-primary-50);
+  --color-red-100: var(--color-primary-100);
+  --color-red-200: var(--color-primary-200);
+  --color-red-300: var(--color-primary-300);
+  --color-red-400: var(--color-primary-400);
+  --color-red-500: var(--color-primary-500);
+  --color-red-600: var(--color-primary-600);
+  --color-red-700: var(--color-primary-700);
+  --color-red-800: var(--color-primary-800);
+  --color-red-900: var(--color-primary-900);
+  --color-red-950: var(--color-primary-950);
+
+  /* shadcn semantic tokens (consumed by src/components/ui/*) */
+  --color-background: #ffffff;
+  --color-foreground: #333333;
+  --color-card: #ffffff;
+  --color-card-foreground: #333333;
+  --color-popover: #ffffff;
+  --color-popover-foreground: #333333;
+  --color-secondary: #f1f5f9;
+  --color-secondary-foreground: #0f172a;
+  --color-muted: #f1f5f9;
+  --color-muted-foreground: #5f6b7a; /* ~5.2:1 on white — AA */
+  --color-accent: #f1f5f9;
+  --color-accent-foreground: #0f172a;
+  --color-destructive: var(--color-primary-600); /* brand is red; errors share it */
+  --color-destructive-foreground: #ffffff;
+  --color-border: #d2d2d2;
+  --color-input: #d2d2d2;
+  --color-ring: var(--color-primary-600);
+  --radius: 0.5rem;
+
+  /* Surfaces & text (referenced by existing inline styles) */
   --color-bg-primary: #ffffff;
   --color-bg-secondary: #f8f9fa;
   --color-text-primary: #333333;
-  --color-text-secondary: #747474;
-  --color-border: #d2d2d2;
-  
-  /* Button Colors */
-  --color-btn-primary-bg: #d8242e;
-  --color-btn-primary-hover: #b01f28;
+  --color-text-secondary: #5f5f5f; /* was #747474 (~4.48:1, below AA); now ~6.3:1 */
+
+  /* Header / Footer (referenced by existing inline styles) */
+  --color-header-bg: #ffffff;
+  --color-header-text: #333333;
+  --color-header-border: #d2d2d2;
+  --color-footer-bg: #000000;
+  --color-footer-text: #ffffff;
+  --color-footer-link-hover: var(--color-primary-light);
+
+  /* Button (referenced by existing inline styles) */
+  --color-btn-primary-bg: var(--color-primary-600);
+  --color-btn-primary-hover: var(--color-primary-700);
   --color-btn-primary-text: #ffffff;
-  
-  /* Typography */
+}
+
+:root {
   font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
@@ -40,28 +93,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-
-  /* shadcn/ui CSS Variables */
-  --background: 0 0% 100%;
-  --foreground: 222.2 84% 4.9%;
-  --card: 0 0% 100%;
-  --card-foreground: 222.2 84% 4.9%;
-  --popover: 0 0% 100%;
-  --popover-foreground: 222.2 84% 4.9%;
-  --primary: 346 77% 49.8%;
-  --primary-foreground: 355.7 100% 97.3%;
-  --secondary: 210 40% 96%;
-  --secondary-foreground: 222.2 84% 4.9%;
-  --muted: 210 40% 96%;
-  --muted-foreground: 215.4 16.3% 46.9%;
-  --accent: 210 40% 96%;
-  --accent-foreground: 222.2 84% 4.9%;
-  --destructive: 0 84.2% 60.2%;
-  --destructive-foreground: 210 40% 98%;
-  --border: 214.3 31.8% 91.4%;
-  --input: 214.3 31.8% 91.4%;
-  --ring: 346 77% 49.8%;
-  --radius: 0.5rem;
 }
 
 /* Base Styles */


### PR DESCRIPTION
## Why

The design review found the color system fragmented across **four** partly-dead schemes:

| System | State before |
|---|---|
| `--color-primary` (#d8242e) | defined but used by only 2 inline styles |
| `bg-red-600` (Tailwind, #dc2626) | the *actual* brand color in ~250 places — a **different** red |
| shadcn HSL `--primary: 346 77%…` | read by nothing |
| `bg-primary` / `text-primary` / `primary-500/600/700` scale | used in `ui/` primitives + MemberFilters/ContactPage/RegistrationPage but emitted **no CSS** (no `@theme` existed) → badges, checkbox fill, gallery filter-count chips, contact icons rendered with **no brand color** |

## What

One Tailwind v4 `@theme` block as the single source of truth: a brand-red ramp anchored at `primary-600` (#d8242e), with the `red-*` scale, the `primary-*` scale, the `bg-primary`/`text-primary` token, and shadcn semantic tokens (`destructive`, `ring`, `border`, `muted-foreground`, …) **all aliased to it**. No component markup changed — every class the code already uses now resolves to the same brand red.

Also fixes the WCAG issue from the review: `--color-text-secondary` #747474 (~4.48:1, below AA) → #5f5f5f (~6.3:1).

## Verification
- `npm run build` ✓ · `lint` ✓ (0 errors) · `test` ✓ (111)
- Previewed the worktree in-browser. Computed styles confirm `bg-primary`, `bg-primary-600`, `bg-red-600`, `text-primary`, `bg-destructive` **all = rgb(216,36,46)**; `text-red-400` = brand ramp #ec6169; `--color-text-secondary` = #5f5f5f. Homepage renders on-brand, no layout regressions.

## Note for review
Because brand identity *is* red, `destructive` (errors, the "Empleada" availability badge) now shares the brand red rather than a separate error-red. This matches prior behaviour and keeps one red — split it later if you want errors visually distinct from CTAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)