### PR TITLE
fix(header): make the 'Sobre Nosotras' submenu reachable

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -95,18 +95,23 @@ export function Header() {
                       >
                         <span className="whitespace-nowrap">{item.name}</span>
                       </Link>
-                      {/* Hover submenu */}
-                      <div className="absolute left-0 top-full mt-1 hidden group-hover:block bg-black border border-gray-800 rounded-md shadow-lg min-w-[180px] z-50">
-                        {aboutMenu.map((sub) => (
-                          <Link
-                            key={sub.href}
-                            to={sub.href}
-                            className="block px-3 py-2 text-sm text-white hover:bg-gray-900 hover:text-red-400 transition-colors duration-200 first:rounded-t-md last:rounded-b-md"
-                            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-                          >
-                            {sub.name}
-                          </Link>
-                        ))}
+                      {/* Hover submenu. The outer wrapper is flush with the trigger
+                          (top-full, no margin) and uses transparent pt-1 padding as a
+                          hoverable bridge — a margin gap here would drop group-hover as
+                          the pointer crosses it, making the submenu unreachable. */}
+                      <div className="absolute left-0 top-full hidden group-hover:block group-focus-within:block pt-1 min-w-[180px] z-50">
+                        <div className="bg-black border border-gray-800 rounded-md shadow-lg overflow-hidden">
+                          {aboutMenu.map((sub) => (
+                            <Link
+                              key={sub.href}
+                              to={sub.href}
+                              className="block px-3 py-2 text-sm text-white hover:bg-gray-900 hover:text-red-400 transition-colors duration-200"
+                              onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+                            >
+                              {sub.name}
+                            </Link>
+                          ))}
+                        </div>
                       </div>
                     </div>
                   ) : (


### PR DESCRIPTION
## Bug
The **Sobre Nosotras → Fundadoras** dropdown couldn't be selected. Root cause (reproduced in-browser): the submenu used `mt-1` — a **4px margin** below the trigger. That margin is a transparent dead zone belonging to neither the trigger nor the panel, so moving the pointer down across it dropped `:hover` on the `.group`, closing the menu before you reached it.

Verified live: trigger bottom = 50px, panel top = 55px → a 5px gap with no hoverable element in between.

## Fix
Keep the 4px visual gap but turn it into a **hoverable bridge**:
- wrapper is now flush with the trigger (`top-full`, no margin) with transparent `pt-1` padding
- the visible black panel moves to an inner `div`
- added `group-focus-within:block` so the submenu also opens on keyboard focus

Verified after the fix: wrapper top (50) = trigger bottom (50), 4px visual gap preserved, and a point inside the gap now hits the bridge wrapper → `group-hover` stays active all the way to Fundadoras.

## Verification
`npm run build` ✓ · `eslint` ✓ · in-browser geometry/hit-testing ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)