### PR TITLE
feat(socias): color-code availability, drop emoji dots, show location

### DIFF
--- a/src/pages/socias/MemberCard.tsx
+++ b/src/pages/socias/MemberCard.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import type { Member } from '@/types/member';
 import { memo } from 'react';
+import { getAvailabilityStyle } from './availability';
 
 interface MemberCardProps {
   member: Member;
@@ -20,7 +21,9 @@ const MemberCardComponent = ({ member, onClick }: MemberCardProps) => {
         ? [member.main_profession]
         : [];
   const availabilityStatus = member.availability_status || 'Disponible';
+  const availability = getAvailabilityStyle(availabilityStatus);
   const isFounder = member.is_founder === true;
+  const location = [member.city, member.country].filter(Boolean).join(', ');
 
   return (
     <Card
@@ -53,27 +56,17 @@ const MemberCardComponent = ({ member, onClick }: MemberCardProps) => {
             ) : (
               <span />
             )}
-            <Badge 
-              variant={
-                availabilityStatus === 'Disponible' ? 'default' : 
-                availabilityStatus === 'Empleada' ? 'destructive' : 
-                'secondary'
-              }
-            >
-              <span className="flex items-center space-x-1">
-                {availabilityStatus === 'Disponible' && (
-                  <span title="Disponible - Abierta a nuevas oportunidades laborales">🟢</span>
-                )}
-                {availabilityStatus === 'Empleada' && (
-                  <span title="Empleada - Actualmente trabajando, no disponible para nuevas oportunidades">🔴</span>
-                )}
-                {availabilityStatus === 'Freelance' && (
-                  <span title="Freelance - Trabajando por cuenta propia, disponible para proyectos">🔵</span>
-                )}
-                <span>{availabilityStatus}</span>
-              </span>
+            <Badge variant="outline" className={availability.badgeClass} title={availability.title}>
+              {availabilityStatus}
             </Badge>
           </div>
+
+          {location && (
+            <p className="flex items-center gap-1.5 text-sm text-gray-300">
+              <span aria-hidden="true">📍</span>
+              <span className="truncate">{location}</span>
+            </p>
+          )}
 
           <div>
             <p className="text-sm text-gray-300 font-medium mb-1">Especializaciones:</p>

--- a/src/pages/socias/MemberFilters.tsx
+++ b/src/pages/socias/MemberFilters.tsx
@@ -84,7 +84,7 @@ export function MemberFilters({
 
             <TabsContent value="location">
               {availableLocations.length === 0 ? (
-                <p className="text-xs text-gray-500 py-1">Las ubicaciones se cargan con los datos de socias.</p>
+                <p className="text-xs text-gray-400 py-1">Las ubicaciones se cargan con los datos de socias.</p>
               ) : (
                 <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-x-2 gap-y-0 max-h-40 overflow-y-auto">
                   {availableLocations.map((location) => (
@@ -112,7 +112,7 @@ export function MemberFilters({
                     />
                     <span className="text-xs text-gray-300">
                       {status}
-                      <span className="ml-1 text-gray-500">({memberCounts.byAvailability[status] || 0})</span>
+                      <span className="ml-1 text-gray-400">({memberCounts.byAvailability[status] || 0})</span>
                     </span>
                   </label>
                 ))}
@@ -137,7 +137,7 @@ export function MemberFilters({
                         />
                         <span className="text-xs text-gray-300">
                           {label}
-                          <span className="ml-1 text-gray-500">({memberCounts.byType[value] || 0})</span>
+                          <span className="ml-1 text-gray-400">({memberCounts.byType[value] || 0})</span>
                         </span>
                       </label>
                     ))}

--- a/src/pages/socias/MemberModal.tsx
+++ b/src/pages/socias/MemberModal.tsx
@@ -3,6 +3,7 @@ import { SocialMediaIcons } from '@/components/SocialMediaIcons';
 import { Badge } from '@/components/ui/badge';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import type { Member } from '@/types/member';
+import { getAvailabilityStyle } from './availability';
 
 interface MemberModalProps {
   member: Member;
@@ -12,7 +13,9 @@ interface MemberModalProps {
 
 export function MemberModal({ member, isOpen, onClose }: MemberModalProps) {
   const availabilityStatus = member.availability_status || 'Disponible';
+  const availability = getAvailabilityStyle(availabilityStatus);
   const isFounder = member.is_founder === true;
+  const location = [member.city, member.country].filter(Boolean).join(', ');
 
   const membershipLabel =
     member.membership_type === 'pleno_derecho'
@@ -55,19 +58,8 @@ export function MemberModal({ member, isOpen, onClose }: MemberModalProps) {
                     ⭐ Fundadora
                   </Badge>
                 )}
-                <Badge 
-                  variant={
-                    availabilityStatus === 'Disponible' ? 'default' : 
-                    availabilityStatus === 'Empleada' ? 'destructive' : 
-                    'secondary'
-                  }
-                >
-                  <span className="flex items-center space-x-1">
-                    {availabilityStatus === 'Disponible' && <span>🟢</span>}
-                    {availabilityStatus === 'Empleada' && <span>🔴</span>}
-                    {availabilityStatus === 'Freelance' && <span>🔵</span>}
-                    <span>{availabilityStatus}</span>
-                  </span>
+                <Badge variant="outline" className={availability.badgeClass} title={availability.title}>
+                  {availabilityStatus}
                 </Badge>
               </div>
             </div>
@@ -109,8 +101,8 @@ export function MemberModal({ member, isOpen, onClose }: MemberModalProps) {
             <h4 className="text-sm font-medium text-gray-200 mb-2">Ubicación</h4>
             <div className="text-sm text-gray-300 space-y-1">
               <p className="flex items-center">
-                <span className="text-gray-500 mr-2">🌍</span>
-                {member.country || 'España'}
+                <span className="mr-2" aria-hidden="true">🌍</span>
+                {location || member.country || 'España'}
               </p>
             </div>
           </div>

--- a/src/pages/socias/availability.ts
+++ b/src/pages/socias/availability.ts
@@ -1,0 +1,32 @@
+// Availability status presentation shared by the member card and modal.
+// Colour-coded (not emoji) so the status reads at a glance while the text label
+// keeps it accessible — never colour alone. Light 300-level text on the dark
+// card/modal clears WCAG AA.
+
+export type AvailabilityStatus = 'Disponible' | 'Empleada' | 'Freelance';
+
+interface AvailabilityStyle {
+  /** Outline-badge classes: text + border + faint fill. */
+  badgeClass: string;
+  /** Tooltip explaining the status. */
+  title: string;
+}
+
+const STYLES: Record<string, AvailabilityStyle> = {
+  Disponible: {
+    badgeClass: 'border-emerald-500/60 text-emerald-300 bg-emerald-500/10',
+    title: 'Disponible — abierta a nuevas oportunidades laborales',
+  },
+  Empleada: {
+    badgeClass: 'border-slate-500/60 text-slate-300 bg-slate-600/20',
+    title: 'Empleada — actualmente trabajando, no busca nuevas oportunidades',
+  },
+  Freelance: {
+    badgeClass: 'border-sky-500/60 text-sky-300 bg-sky-500/10',
+    title: 'Freelance — trabaja por cuenta propia, disponible para proyectos',
+  },
+};
+
+export function getAvailabilityStyle(status: string | undefined): AvailabilityStyle {
+  return STYLES[status ?? ''] ?? STYLES.Disponible;
+}


### PR DESCRIPTION
## What you asked for
- **Remove the green dot** from the card → done. The 🟢/🔴/🔵 emoji are gone from both card and modal.
- **Availability now reads via colour + text** (accessible, never colour-only): green = Disponible, slate = Empleada, sky = Freelance. This also fixes a latent bug — the old generic `default`/`destructive` Badge variants are dead tokens on `dev` and would both render red after the token PR.
- **Member name stays white** — measured 14.3:1 on the dark card; brand red would be ~3:1 (fails AA and looks muddy). Recommendation: white.
- **New field: location** (city, país) on the card, with a 📍 pin; and the modal's Ubicación now includes the city (was country only).

Shared `getAvailabilityStyle()` helper keeps card + modal DRY.

## Not in this PR (separate)
The **filter checkbox is barely visible** (measured 1.16:1 border contrast) because `border-input`/`bg-primary` are **dead tokens** on `dev`. That's fixed by **#126** (the `@theme` consolidation), which defines those tokens. Merge #126 and the checkboxes + tab count-badges become visible.

## Verification
`npm run build` ✓ · `eslint` ✓ · verified in-browser against live dev data (24 cards): green badge, location pins, no emoji, modal correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)