### PR TITLE
fix(ui): white-on-white card text on Membresía and Sobre Nosotras

### DIFF
--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -186,8 +186,8 @@ export function AboutPage() {
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                 </div>
-                <h3 className="text-xl font-semibold text-white mb-4">Promover la igualdad de género</h3>
-                <p className="text-gray-300 leading-relaxed">
+                <h3 className="text-xl font-semibold text-gray-900 mb-4">Promover la igualdad de género</h3>
+                <p className="text-gray-700 leading-relaxed">
                   Promover la igualdad de género en la industria de la animación.
                 </p>
               </CardContent>
@@ -208,8 +208,8 @@ export function AboutPage() {
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
                   </svg>
                 </div>
-                <h3 className="text-xl font-semibold text-white mb-4">Visibilizar el talento femenino</h3>
-                <p className="text-gray-300 leading-relaxed">
+                <h3 className="text-xl font-semibold text-gray-900 mb-4">Visibilizar el talento femenino</h3>
+                <p className="text-gray-700 leading-relaxed">
                   Visibilizar el talento femenino y de género diverso en festivales, estudios, eventos y medios.
                 </p>
               </CardContent>
@@ -229,8 +229,8 @@ export function AboutPage() {
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
                   </svg>
                 </div>
-                <h3 className="text-xl font-semibold text-white mb-4">Fomentar formación y networking</h3>
-                <p className="text-gray-300 leading-relaxed">
+                <h3 className="text-xl font-semibold text-gray-900 mb-4">Fomentar formación y networking</h3>
+                <p className="text-gray-700 leading-relaxed">
                   Fomentar la formación, el networking y el desarrollo profesional.
                 </p>
               </CardContent>
@@ -250,8 +250,8 @@ export function AboutPage() {
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
                   </svg>
                 </div>
-                <h3 className="text-xl font-semibold text-white mb-4">Actuar como agente de cambio</h3>
-                <p className="text-gray-300 leading-relaxed">
+                <h3 className="text-xl font-semibold text-gray-900 mb-4">Actuar como agente de cambio</h3>
+                <p className="text-gray-700 leading-relaxed">
                   Actuar como agente de cambio a través de alianzas con instituciones, escuelas y empresas del sector.
                 </p>
               </CardContent>

--- a/src/pages/MembershipPage.tsx
+++ b/src/pages/MembershipPage.tsx
@@ -97,7 +97,7 @@ export function MembershipPage() {
 
                 {/* Description */}
                 <div className="min-h-[5rem] flex items-center justify-center mb-6">
-                  <p className="text-white">
+                  <p className="text-gray-700">
                     {membership.description}
                   </p>
                 </div>
@@ -122,7 +122,7 @@ export function MembershipPage() {
                       <svg className="h-5 w-5 text-green-500 mt-0.5 mr-3 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
                         <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
                       </svg>
-                      <span className="text-sm text-white">{benefit}</span>
+                      <span className="text-sm text-gray-700">{benefit}</span>
                     </li>
                   ))}
                 </ul>


### PR DESCRIPTION
## Problem

On the **Membresía** cards and the four "objectives" cards on **Sobre Nosotras**, the cards have a white background but the text was white (`text-white`) — so the descriptions and benefit lists were **invisible** (white-on-white). Some descriptions were `text-gray-300`, too faint on white.

## Fix

- **Membresía cards:** membership description and benefit list → `text-gray-700`.
- **Sobre Nosotras objective cards:** titles `text-white` → `text-gray-900`; descriptions `text-gray-300` → `text-gray-700`.

Dark text on the white cards, readable and AA-compliant. Titles/prices (red) and icons are unchanged.

Pre-existing bug (present on the live site), split out from the Phase 2 work so it can ship independently.

## Verification
- `npm run build` ✅ · lint ✅ (no new errors)
- Browser: all affected text now renders dark on the white cards (verified white-on-white is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)