### PR TITLE
fix(ui): clean focus rings, red active borders, footer + CTA polish

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,5 @@
 import { Mail } from 'lucide-react';
 import { Facebook, Twitter, Instagram, Linkedin } from '@/components/icons/BrandIcons';
-import { Link } from 'react-router-dom';
 import { FooterLink } from './FooterLink';
 import { siteConfig } from '@/config/site.config';
 
@@ -97,7 +96,7 @@ export function Footer() {
           </div>
 
           {/* Right Column - Membership CTA */}
-          <div className="lg:col-span-3 flex flex-col justify-between h-full">
+          <div className="lg:col-span-3 flex flex-col">
             <div className="space-y-4">
               <h3 className="text-lg font-semibold">ÚNETE A MIA</h3>
               <p className="text-sm text-gray-300">
@@ -117,22 +116,14 @@ export function Footer() {
                   Socia Colaboradora
                 </li>
               </ul>
-            </div>
-            <div className="flex flex-col gap-3 pt-6">
               <a
                 href={siteConfig.wildApricot.signupUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="w-full bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded text-center text-sm transition-colors duration-200"
+                className="inline-block w-full bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded text-center text-sm transition-colors duration-200 mt-2"
               >
-                ÚNETE A MIA
+                Hazte socia
               </a>
-              <Link
-                to="/membresia"
-                className="w-full border border-gray-600 hover:border-gray-400 text-gray-300 hover:text-white font-medium py-2 px-4 rounded text-center text-sm transition-colors duration-200"
-              >
-                Ver membresías
-              </Link>
             </div>
           </div>
         </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,7 +2,6 @@ import { Mail } from 'lucide-react';
 import { Facebook, Twitter, Instagram, Linkedin } from '@/components/icons/BrandIcons';
 import { Link } from 'react-router-dom';
 import { FooterLink } from './FooterLink';
-import { Button } from '@/components/ui/button';
 import { siteConfig } from '@/config/site.config';
 
 export function Footer() {
@@ -29,13 +28,6 @@ export function Footer() {
               <FooterLink to="/mianima">MIANIMA</FooterLink>
               <FooterLink to="/membresia">MEMBRESÍA</FooterLink>
               <FooterLink to="/contacto">CONTACTO</FooterLink>
-              <Button
-                variant="link"
-                asChild
-                className="text-base text-gray-300 p-0 h-auto hover:text-red-400 transition-colors duration-200 justify-start"
-              >
-                <a href={siteConfig.wildApricot.signupUrl} target="_blank" rel="noopener noreferrer">ÚNETE A MIA</a>
-              </Button>
             </nav>
           </div>
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -81,7 +81,7 @@ export function Header() {
                       <Link
                         to={item.href}
                         className={`inline-block ${isActive(item.href) || aboutMenu.some((i) => isActive(i.href))
-                          ? 'text-white bg-gray-800 px-3 py-2 rounded-md text-sm font-medium border border-white transition-colors duration-200'
+                          ? 'text-white bg-gray-800 px-3 py-2 rounded-md text-sm font-medium border border-red-600 transition-colors duration-200'
                           : 'text-white hover:text-red-400 px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200'
                         }`}
                         onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
@@ -112,7 +112,7 @@ export function Header() {
                       key={item.name}
                       to={item.href}
                       className={`inline-block flex-shrink-0 ${isActive(item.href)
-                        ? 'text-white bg-gray-800 px-3 py-2 rounded-md text-sm font-medium border border-white transition-colors duration-200'
+                        ? 'text-white bg-gray-800 px-3 py-2 rounded-md text-sm font-medium border border-red-600 transition-colors duration-200'
                         : 'text-white hover:text-red-400 px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200'
                       }`}
                       onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}

--- a/src/components/HeaderMobileMenu.tsx
+++ b/src/components/HeaderMobileMenu.tsx
@@ -32,7 +32,7 @@ export function HeaderMobileMenu({ mobileMenuRef, navigation, aboutMenu, isActiv
             to={item.href}
             className={`block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200 whitespace-nowrap ${
               isActive(item.href)
-                ? 'text-white bg-gray-800 border border-white'
+                ? 'text-white bg-gray-800 border border-red-600'
                 : 'text-white hover:bg-gray-900 hover:text-red-400'
             }`}
             onClick={handleClick}
@@ -70,7 +70,7 @@ export function HeaderMobileMenu({ mobileMenuRef, navigation, aboutMenu, isActiv
               to={item.href}
               className={`block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200 whitespace-nowrap ${
                 isActive(item.href)
-                  ? 'text-white bg-gray-800 border border-white'
+                  ? 'text-white bg-gray-800 border border-red-600'
                   : 'text-white hover:bg-gray-900 hover:text-red-400'
               }`}
               onClick={handleClick}

--- a/src/index.css
+++ b/src/index.css
@@ -124,32 +124,14 @@ body {
   }
 }
 
-/* Enhanced Focus Indicators */
-*:focus {
-  outline: 2px solid #ef4444;
-  outline-offset: 2px;
-}
-
+/* Focus indicators — keyboard only.
+   Mouse clicks no longer leave an outline (the old *:focus rule fired on click).
+   A subtle brand-red ring shows only for keyboard navigation, satisfying
+   WCAG 2.4.7 without the heavy amber boxes. */
 *:focus-visible {
-  outline: 2px solid #ef4444;
+  outline: 2px solid var(--color-primary);
   outline-offset: 2px;
-  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.2);
-}
-
-/* High contrast focus for interactive elements */
-button:focus-visible,
-a:focus-visible,
-input:focus-visible,
-textarea:focus-visible,
-select:focus-visible,
-[role="button"]:focus-visible,
-[role="link"]:focus-visible,
-[tabindex]:focus-visible {
-  outline: 3px solid #fbbf24;
-  outline-offset: 2px;
-  box-shadow: 0 0 0 1px #000, 0 0 0 4px #fbbf24;
-  position: relative;
-  z-index: 10;
+  border-radius: 3px;
 }
 
 /* Skip link styling */
@@ -171,15 +153,6 @@ select:focus-visible,
   left: 0;
   font-weight: 600;
   border-radius: 0 0 4px 0;
-}
-
-/* Improved contrast for dark backgrounds */
-.dark *:focus-visible,
-.bg-gray-900 *:focus-visible,
-.bg-black *:focus-visible {
-  outline: 3px solid #fbbf24;
-  outline-offset: 2px;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.8), 0 0 0 5px #fbbf24;
 }
 
 /* Directiva card entrance animation */

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -390,15 +390,13 @@ export function AboutPage() {
           <div className="flex flex-col sm:flex-row justify-center space-y-4 sm:space-y-0 sm:space-x-4">
             <Button
               onClick={() => window.location.href = '/membresia'}
-              variant="outline"
-              className="border-2 border-white text-white hover:bg-white hover:text-red-600"
+              className="w-full sm:w-auto"
             >
               Hazte socia
             </Button>
             <Button
               onClick={() => window.location.href = '/contacto'}
-              variant="outline"
-              className="border-2 border-white text-white hover:bg-white hover:text-red-600"
+              className="w-full sm:w-auto"
             >
               Contáctanos
             </Button>


### PR DESCRIPTION
Four UI fixes from review of the live dev site.

### 1. Focus 'boxes' on logo / menu (accessibility)
The global `*:focus` rule fired on **mouse clicks**, leaving a persistent outline box on the logo and nav items, and the `:focus-visible` rules used heavy amber double-rings. Removed both; replaced with a single **subtle keyboard-only brand-red ring**. Mouse clicks no longer show a box; keyboard focus still does (WCAG 2.4.7 preserved). Verified: `*:focus` rule gone, `:focus-visible` = `2px solid var(--color-primary)`.

### 2. Active-nav border white → red
The active nav item used `border border-white`; now `border border-red-600` (Header + mobile menu). Verified computed border = rgb(216,36,46).

### 3. Footer: remove redundant 'Únete a MIA' link
The left nav had a 'ÚNETE A MIA' link duplicating the right-column CTA. Removed it (and the now-unused `Button` import). The prominent red CTA stays.

### 4. AboutPage CTA buttons white-on-white → red
`variant="outline"` now resolves `bg-background` = white (from the token PR), so 'Hazte socia' / 'Contáctanos' rendered as blank white buttons with white text. Switched to the standard red primary button, matching every other CTA.

### Verification
`npm run build` ✓ · `eslint` ✓ (0 errors) · verified each fix in-browser at 1280px against live data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)