### PR TITLE
feat(membership): embed WildApricot signup widget on /membresia

### DIFF
--- a/src/components/WildApricotMembershipWidget.tsx
+++ b/src/components/WildApricotMembershipWidget.tsx
@@ -36,7 +36,7 @@ export function WildApricotMembershipWidget() {
         title="Iniciar membresía en MIA"
         src={WIDGET_SRC}
         className="block w-full border-0 bg-transparent"
-        style={{ height: '900px' }}
+        style={{ height: '720px' }}
         allow="payment"
         onLoad={() => window.tryToEnableWACookies?.(WA_ORIGIN)}
       />

--- a/src/components/WildApricotMembershipWidget.tsx
+++ b/src/components/WildApricotMembershipWidget.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from 'react';
+
+// Official WildApricot membership-signup widget, embedded so members can join
+// without leaving the app. The iframe is cross-origin (we can't auto-size it to
+// its content), so it uses a generous fixed height and the widget scrolls
+// internally if its form is taller. EnableCookies.js is WildApricot's helper
+// that lets their session cookies work inside the iframe; the iframe's onLoad
+// invokes it (replacing the raw onload="" attribute from WA's snippet).
+
+const WA_ORIGIN = 'https://web.animacionesmia.com';
+const WIDGET_SRC = `${WA_ORIGIN}/widget/iniciar-membresia`;
+const COOKIES_SCRIPT = `${WA_ORIGIN}/Common/EnableCookies.js`;
+
+declare global {
+  interface Window {
+    tryToEnableWACookies?: (origin: string) => void;
+  }
+}
+
+export function WildApricotMembershipWidget() {
+  // Load WildApricot's cookie helper once (it defines tryToEnableWACookies).
+  useEffect(() => {
+    if (document.querySelector(`script[src="${COOKIES_SCRIPT}"]`)) return;
+    const script = document.createElement('script');
+    script.src = COOKIES_SCRIPT;
+    script.async = true;
+    document.body.appendChild(script);
+  }, []);
+
+  return (
+    <div className="mx-auto w-full max-w-3xl">
+      <div className="overflow-hidden rounded-lg bg-white shadow-lg">
+        <iframe
+          title="Iniciar membresía en MIA"
+          src={WIDGET_SRC}
+          className="block w-full border-0"
+          style={{ height: '900px' }}
+          onLoad={() => window.tryToEnableWACookies?.(WA_ORIGIN)}
+        />
+      </div>
+      <p className="mt-2 text-center text-[10px] text-gray-500">
+        Gestionado por Wild Apricot{' '}
+        <a
+          href="http://www.wildapricot.com/features"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-gray-400"
+        >
+          Membership Software
+        </a>
+      </p>
+    </div>
+  );
+}

--- a/src/components/WildApricotMembershipWidget.tsx
+++ b/src/components/WildApricotMembershipWidget.tsx
@@ -29,14 +29,14 @@ export function WildApricotMembershipWidget() {
 
   return (
     <div className="mx-auto w-full max-w-3xl">
-      {/* No card/background: the WildApricot page is dark, so a transparent
-          wrapper lets it blend into the dark membership page (and a transparent
-          WA background will show the page through). */}
+      {/* Match the page background (bg-gray-900 = #111827) so the iframe area
+          blends with the membership page. Pair this with WA-side CSS that sets
+          the widget's own background to the same colour. */}
       <iframe
         title="Iniciar membresía en MIA"
         src={WIDGET_SRC}
-        className="block w-full border-0 bg-transparent"
-        style={{ height: '720px' }}
+        className="block w-full border-0"
+        style={{ height: '720px', backgroundColor: '#111827' }}
         allow="payment"
         onLoad={() => window.tryToEnableWACookies?.(WA_ORIGIN)}
       />

--- a/src/components/WildApricotMembershipWidget.tsx
+++ b/src/components/WildApricotMembershipWidget.tsx
@@ -29,15 +29,17 @@ export function WildApricotMembershipWidget() {
 
   return (
     <div className="mx-auto w-full max-w-3xl">
-      <div className="overflow-hidden rounded-lg bg-white shadow-lg">
-        <iframe
-          title="Iniciar membresía en MIA"
-          src={WIDGET_SRC}
-          className="block w-full border-0"
-          style={{ height: '900px' }}
-          onLoad={() => window.tryToEnableWACookies?.(WA_ORIGIN)}
-        />
-      </div>
+      {/* No card/background: the WildApricot page is dark, so a transparent
+          wrapper lets it blend into the dark membership page (and a transparent
+          WA background will show the page through). */}
+      <iframe
+        title="Iniciar membresía en MIA"
+        src={WIDGET_SRC}
+        className="block w-full border-0 bg-transparent"
+        style={{ height: '900px' }}
+        allow="payment"
+        onLoad={() => window.tryToEnableWACookies?.(WA_ORIGIN)}
+      />
       <p className="mt-2 text-center text-[10px] text-gray-500">
         Gestionado por Wild Apricot{' '}
         <a

--- a/src/pages/MembershipPage.tsx
+++ b/src/pages/MembershipPage.tsx
@@ -24,6 +24,10 @@ export function MembershipPage() {
           <p className="text-xl text-gray-300 max-w-3xl mx-auto">
             Descubre los beneficios exclusivos que obtienes al formar parte de nuestra comunidad
           </p>
+          <p className="text-lg text-gray-400 max-w-2xl mx-auto mt-4">
+            Completa tu alta aquí mismo. El proceso es seguro y lo gestiona nuestra
+            plataforma de membresía.
+          </p>
         </div>
 
         {/* Benefits Cards */}
@@ -129,14 +133,6 @@ export function MembershipPage() {
                 </ul>
                 </div>
 
-                {/* CTA Button */}
-                <div className="mt-auto">
-                  <Button asChild className="w-full" variant="default">
-                    <a href={siteConfig.wildApricot.signupUrl} target="_blank" rel="noopener noreferrer">
-                      Seleccionar Subscripción
-                    </a>
-                  </Button>
-                </div>
                 </div>
               </CardContent>
             </Card>
@@ -147,15 +143,6 @@ export function MembershipPage() {
 
         {/* Join now — WildApricot signup widget */}
         <div id="iniciar-membresia" className="scroll-mt-20 mb-16">
-          <div className="text-center mb-8">
-            <h2 className="text-3xl font-bold text-white mb-4">
-              Hazte socia
-            </h2>
-            <p className="text-lg text-gray-300 max-w-2xl mx-auto">
-              Completa tu alta aquí mismo. El proceso es seguro y lo gestiona nuestra
-              plataforma de membresía.
-            </p>
-          </div>
           <WildApricotMembershipWidget />
         </div>
 

--- a/src/pages/MembershipPage.tsx
+++ b/src/pages/MembershipPage.tsx
@@ -1,10 +1,7 @@
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Accordion } from '@/components/ui/accordion';
-import { BackgroundImage } from '@/components/ui/background-image';
 import { membershipTypes } from '@/utils/memberships';
-import { siteConfig } from '@/config/site.config';
 import { WildApricotMembershipWidget } from '@/components/WildApricotMembershipWidget';
 
 export function MembershipPage() {
@@ -168,32 +165,8 @@ export function MembershipPage() {
           </Card>
         </div>
 
-        
-      </div>
 
-      {/* Final CTA */}
-      <BackgroundImage 
-        imageUrl="/images/membership-cta.webp"
-        className="py-16 w-full"
-      >
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 className="text-3xl font-bold text-red-600 mb-4">
-            ¿Lista para unirte a MIA?
-          </h2>
-          <p className="text-lg text-white mb-8 max-w-2xl mx-auto">
-            Forma parte de la comunidad de mujeres profesionales en animación 
-            más grande de España. ¡Tu carrera te lo agradecerá!
-          </p>
-          <Button asChild size="lg" className="inline-flex items-center">
-            <a href={siteConfig.wildApricot.signupUrl} target="_blank" rel="noopener noreferrer">
-              Comenzar Registro
-              <svg className="ml-2 -mr-1 w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-                <path fillRule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clipRule="evenodd" />
-              </svg>
-            </a>
-          </Button>
-        </div>
-      </BackgroundImage>
+      </div>
     </div>
   );
 }

--- a/src/pages/MembershipPage.tsx
+++ b/src/pages/MembershipPage.tsx
@@ -5,6 +5,7 @@ import { Accordion } from '@/components/ui/accordion';
 import { BackgroundImage } from '@/components/ui/background-image';
 import { membershipTypes } from '@/utils/memberships';
 import { siteConfig } from '@/config/site.config';
+import { WildApricotMembershipWidget } from '@/components/WildApricotMembershipWidget';
 
 export function MembershipPage() {
   const [selectedMembership, setSelectedMembership] = useState<string | null>(null);
@@ -143,6 +144,20 @@ export function MembershipPage() {
         </div>
 
 
+
+        {/* Join now — WildApricot signup widget */}
+        <div id="iniciar-membresia" className="scroll-mt-20 mb-16">
+          <div className="text-center mb-8">
+            <h2 className="text-3xl font-bold text-white mb-4">
+              Hazte socia
+            </h2>
+            <p className="text-lg text-gray-300 max-w-2xl mx-auto">
+              Completa tu alta aquí mismo. El proceso es seguro y lo gestiona nuestra
+              plataforma de membresía.
+            </p>
+          </div>
+          <WildApricotMembershipWidget />
+        </div>
 
         {/* FAQ Section */}
         <div className="text-center mb-12">

--- a/src/pages/MembershipPage.tsx
+++ b/src/pages/MembershipPage.tsx
@@ -24,10 +24,6 @@ export function MembershipPage() {
           <p className="text-xl text-gray-300 max-w-3xl mx-auto">
             Descubre los beneficios exclusivos que obtienes al formar parte de nuestra comunidad
           </p>
-          <p className="text-lg text-gray-400 max-w-2xl mx-auto mt-4">
-            Completa tu alta aquí mismo. El proceso es seguro y lo gestiona nuestra
-            plataforma de membresía.
-          </p>
         </div>
 
         {/* Benefits Cards */}
@@ -107,18 +103,6 @@ export function MembershipPage() {
                   </p>
                 </div>
 
-                {/* Price */}
-                <div className="min-h-[5rem] flex items-center justify-center mb-8">
-                  <div className="flex items-baseline">
-                    <span className="text-5xl font-bold text-red-600">
-                      €{membership.price}
-                    </span>
-                    <span className="text-lg text-red-600 ml-2">
-                      /año
-                    </span>
-                  </div>
-                </div>
-
                 {/* Benefits */}
                 <div className="flex-grow mb-8">
                   <ul className="text-left space-y-3 min-h-[200px]">
@@ -142,7 +126,11 @@ export function MembershipPage() {
 
 
         {/* Join now — WildApricot signup widget */}
-        <div id="iniciar-membresia" className="scroll-mt-20 mb-16">
+        <div id="iniciar-membresia" className="scroll-mt-20 mb-12">
+          <p className="text-center text-xl text-gray-300 max-w-2xl mx-auto mb-6">
+            Completa tu alta aquí mismo. El proceso es seguro y lo gestiona nuestra
+            plataforma de membresía.
+          </p>
           <WildApricotMembershipWidget />
         </div>
 


### PR DESCRIPTION
Embeds WildApricot's official membership signup form directly on `/membresia` so members can join within the app, and streamlines the page around it.

## Changes (app side, this PR)
- **New `WildApricotMembershipWidget` component** — embeds the WA iframe (`/widget/iniciar-membresia`) at `max-w-3xl`, height `720px`, background `#111827` to match the page (`bg-gray-900`). Loads WA's `EnableCookies.js` once and calls `tryToEnableWACookies` on load (React-safe replacement for WA's raw `onload=""`). `allow="payment"` for the checkout step.
- **Page streamlined** around the widget:
  - Dropped the per-card "Seleccionar Subscripción" buttons (the widget handles selection).
  - Removed the **price** from the plan cards (shown in the widget — was duplicated).
  - Moved the "Completa tu alta aquí mismo…" line to directly above the widget, styled to match the other intro paragraphs.
  - Removed the bottom "¿Lista para unirte a MIA?" CTA (signup now happens in the widget above).
  - Tightened section spacing; cleaned up now-unused imports (`BackgroundImage`, `Button`, `siteConfig`).

Page flow is now: header → benefit cards → plan cards (info only) → intro line + embedded signup widget → FAQ.

## Verification
- `npm run build` ✓ · `eslint` ✓ (0 errors).
- Non-iframe parts verified in-browser (prices gone, intro relocated, final CTA removed, FAQ intact).
- **Note:** the WildApricot iframe is cross-origin, so it renders blank in the automated headless preview — it loads correctly in a real browser (confirmed via live screenshots: dark form, white text, brand-red NEXT). Network shows `widget → 200`, `EnableCookies.js → 200`, `GetCookiesEnabled → 200`.

## Required WildApricot-side config (not in repo, done in WA admin)
The form *inside* the iframe is a different origin, so it's themed via WildApricot's **CSS customization** (scoped to `body.widgetMode` so it only affects embedded widgets, not the main WA site): Inter font, white text, brand-red buttons, and `#111827` container backgrounds to match. Also recommended: set the WA site language to Spanish so the form's system strings ("Select membership level", "Next", …) localize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)