### PR TITLE
feat(membership): point 'Únete a MIA' CTAs to in-app /membresia

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,7 @@
 import { Mail } from 'lucide-react';
 import { Facebook, Twitter, Instagram, Linkedin } from '@/components/icons/BrandIcons';
+import { Link } from 'react-router-dom';
 import { FooterLink } from './FooterLink';
-import { siteConfig } from '@/config/site.config';
 
 export function Footer() {
   return (
@@ -116,14 +116,12 @@ export function Footer() {
                   Socia Colaboradora
                 </li>
               </ul>
-              <a
-                href={siteConfig.wildApricot.signupUrl}
-                target="_blank"
-                rel="noopener noreferrer"
+              <Link
+                to="/membresia"
                 className="inline-block w-full bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded text-center text-sm transition-colors duration-200 mt-2"
               >
                 Hazte socia
-              </a>
+              </Link>
             </div>
           </div>
         </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -122,9 +122,9 @@ export function Header() {
                   )
                 ))}
                 <Button asChild className="shrink-0 bg-red-600 hover:bg-red-700 text-white whitespace-nowrap">
-                  <a href={siteConfig.wildApricot.signupUrl} target="_blank" rel="noopener noreferrer">
+                  <Link to="/membresia" onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}>
                     Únete a MIA
-                  </a>
+                  </Link>
                 </Button>
                 <a
                   href={siteConfig.wildApricot.loginUrl}

--- a/src/components/HeaderMobileMenu.tsx
+++ b/src/components/HeaderMobileMenu.tsx
@@ -43,9 +43,9 @@ export function HeaderMobileMenu({ mobileMenuRef, navigation, aboutMenu, isActiv
 
         <div className="pt-4 pb-2">
           <Button asChild className="w-full bg-red-600 hover:bg-red-700 text-white">
-            <a href={siteConfig.wildApricot.signupUrl} target="_blank" rel="noopener noreferrer" onClick={handleClick}>
+            <Link to="/membresia" onClick={handleClick}>
               Únete a MIA
-            </a>
+            </Link>
           </Button>
         </div>
 

--- a/src/config/site.config.ts
+++ b/src/config/site.config.ts
@@ -6,10 +6,10 @@ export const siteConfig = {
   shortName: 'MIA',
   description: 'Asociación profesional de mujeres en la industria de animación en España',
   url: isDev ? 'https://dev.animacionesmia.com' : 'https://animacionesmia.com',
-  // WildApricot-hosted pages handle membership signup, member login/portal and
-  // contact — the app links out to these instead of running its own flows.
+  // WildApricot-hosted pages for member login/portal and contact. Membership
+  // signup is handled in-app on /membresia (embedded WildApricot widget), so
+  // there's no external signup URL here.
   wildApricot: {
-    signupUrl: 'https://web.animacionesmia.com/membresia',
     loginUrl: 'https://web.animacionesmia.com/Sys/Login',
     contactUrl: 'https://web.animacionesmia.com/contacto',
   },

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -123,9 +123,9 @@ export function ContactPage() {
                     content: (
                       <>
                         Solo tienes que rellenar el formulario de inscripción disponible en nuestra web y seguir los pasos indicados. Una vez validada la solicitud, recibirás un correo de bienvenida con toda la información.{' '}
-                        <a href={siteConfig.wildApricot.signupUrl} target="_blank" rel="noopener noreferrer" className="text-red-600 hover:text-red-700 underline font-medium">
+                        <Link to="/membresia" className="text-red-600 hover:text-red-700 underline font-medium">
                           Únete a MIA
-                        </a>
+                        </Link>
                       </>
                     )
                   },


### PR DESCRIPTION
Now that `/membresia` embeds the WildApricot signup widget, the 'Únete a MIA' / 'Hazte socia' CTAs (Header, mobile menu, Footer, and the Contact FAQ link) route to the **internal /membresia page** instead of opening WildApricot's full signup page in a new tab.

Why: keeps signup to a single path inside the app chrome and avoids the 'two menus' problem (the external WA page carries its own header/nav).

- Replaced the external `<a href={signupUrl} target=_blank>` CTAs with `<Link to="/membresia">`.
- Removed the now-unused `wildApricot.signupUrl` from `site.config.ts` (login + contact external URLs remain).

Verified in-browser: header CTA href is `/membresia`, no `target=_blank`, clicking navigates in-app; no external signup links remain. `build` ✓ `lint` ✓.

Supersedes #133 (which only flipped the external signup URL) — closing that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)