### PR TITLE
fix(gallery): serve WildApricot member photos via proxy worker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,7 @@ See `.claude/agents/git-workflow.md` for full branching, commit, PR, and merge r
 
 ## Known Issues / TODOs
 
-- **Member photos** — the gallery reads WildApricot profile pictures (`ProfileImage.Url`); pending the Supabase→WildApricot photo import. Verify those URLs are publicly loadable by an `<img>` once added.
+- **Member photos** — served via the `/api/members/:id/photo` proxy Worker. WildApricot has no native avatar field on this account; the photo lives in a custom Picture field (`fotoPerfil`, `custom-17813785`), absent from the async list and behind an auth-gated URL. The proxy resolves the contact's photo URL, fetches it with the WA token, and streams it publicly (cached in Cache API + KV `photo_url:<id>`, 24h). Members with no photo redirect to `/avatar-placeholder.jpg`.
 - Member stats in `HomePage` (`MEMBER_STATS`) — hardcoded. Needs a product decision on what "active/total members" means (WA total vs gallery-visible count) before wiring to a live source.
 - `HomePage` "85% growth" / "50 events" counters — static marketing numbers, no source
 - Token/color system — brand red is defined as `--color-primary` but components hardcode `bg-red-600` (a different red), and a third value lives in the shadcn HSL tokens. Consolidate to a single Tailwind `@theme` source of truth.

--- a/functions/_lib/wa-field-ids.ts
+++ b/functions/_lib/wa-field-ids.ts
@@ -13,6 +13,10 @@ export const FIELD_CODES = {
   twitter: 'custom-17813771',
   website: 'custom-17813776',
   statusEmpleo: 'custom-17813772',
+  // Member profile photo. WildApricot has no native/system avatar field on this
+  // account — the photo members upload lives in this custom Picture field, whose
+  // value is { Id, Url } with an auth-gated api.wildapricot.org Pictures URL.
+  fotoPerfil: 'custom-17813785',
 } as const;
 
 export const COUNTRY_CODE_TO_LABEL: Record<string, string> = {

--- a/functions/api/members.ts
+++ b/functions/api/members.ts
@@ -25,7 +25,6 @@ interface WAContact {
   DisplayName?: string;
   MembershipLevel?: { Id: number; Name: string };
   MemberSince?: string;
-  ProfileImage?: { Url?: string; IsDefault?: boolean };
   FieldValues?: WAFieldValue[];
 }
 
@@ -65,16 +64,14 @@ function normalizeMembershipType(env: Env, level?: { Id: number; Name: string })
 
 function transformContact(env: Env, contact: WAContact): object {
   const fields = contact.FieldValues;
-  const photo = contact.ProfileImage;
-  // Member photos are pending migration from Supabase to R2; the WildApricot photo
-  // field holds unusable Google Forms upload links, so we ignore it and fall back to
-  // the system avatar (empty for now → initials placeholder in the UI).
   return {
     id: String(contact.Id),
     first_name: contact.FirstName,
     last_name: contact.LastName,
     display_name: contact.DisplayName,
-    profile_image_url: photo && photo.IsDefault === false ? photo.Url : undefined,
+    // The WildApricot photo is in an auth-gated custom field absent from this async
+    // list, so we point at the photo proxy Worker (resolves + streams it per member).
+    profile_image_url: `/api/members/${contact.Id}/photo`,
     biography: getStringField(fields, FIELD_CODES.bio) || undefined,
     main_profession: getOptionLabel(fields, FIELD_CODES.profesionPrincipal) || undefined,
     other_professions: getOptionLabels(fields, FIELD_CODES.profesionAdicional),

--- a/functions/api/members/[id]/photo.ts
+++ b/functions/api/members/[id]/photo.ts
@@ -1,0 +1,112 @@
+// GET /api/members/:id/photo — member profile photo proxy.
+//
+// The WildApricot photo lives in the custom Picture field `fotoPerfil` and its
+// URL is auth-gated (api.wildapricot.org returns 401 without a Bearer token), so a
+// browser <img> cannot load it directly. This Worker looks up the contact's photo
+// URL, fetches the image WITH the token, and streams it back publicly — caching the
+// bytes in the Cloudflare Cache API and the contact→URL mapping in KV so repeat
+// views cost zero-to-one WildApricot subrequests. Members with no photo redirect to
+// the static placeholder.
+
+import { getWAToken } from '../../../_lib/wa-token';
+import { FIELD_CODES } from '../../../_lib/wa-field-ids';
+import { log, logError } from '../../../_lib/logger';
+
+interface Env {
+  KV: KVNamespace;
+  WILDAPRICOT_API_KEY: string;
+  WILDAPRICOT_ACCOUNT_ID: string;
+}
+
+interface WAFieldValue { SystemCode: string; Value: unknown }
+
+const IMAGE_TTL = 86400; // 24h — matches the gallery cache; photos change rarely
+const PLACEHOLDER = '/avatar-placeholder.jpg';
+
+// KV value for the contact→photo mapping. Empty string is a cached "no photo".
+function photoUrlKey(id: string): string {
+  return `photo_url:${id}`;
+}
+
+function extractPhotoUrl(fields: WAFieldValue[] | undefined): string {
+  const raw = fields?.find(f => f.SystemCode === FIELD_CODES.fotoPerfil)?.Value;
+  if (raw && typeof raw === 'object') {
+    const url = (raw as { Url?: string }).Url;
+    if (typeof url === 'string' && url.trim()) return url.trim();
+  }
+  return '';
+}
+
+interface Context {
+  request: Request;
+  env: Env;
+  params: { id: string | string[] };
+  waitUntil: (p: Promise<unknown>) => void;
+}
+
+export async function onRequestGet(context: Context): Promise<Response> {
+  const { request, env, params } = context;
+  const id = String(Array.isArray(params.id) ? params.id[0] : params.id);
+
+  if (!/^\d+$/.test(id)) {
+    return new Response('Invalid member id', { status: 400 });
+  }
+
+  const cache = caches.default;
+  const cacheKey = new Request(new URL(request.url).toString(), { method: 'GET' });
+  const hit = await cache.match(cacheKey);
+  if (hit) {
+    log('gallery.photo_cache_hit', { contactId: id });
+    return hit;
+  }
+
+  try {
+    const token = await getWAToken(env);
+    const auth = { Authorization: `Bearer ${token}` };
+
+    // 1. Resolve contact → photo URL, cached in KV (empty string = known no-photo).
+    let photoUrl = await env.KV.get(photoUrlKey(id));
+    if (photoUrl === null) {
+      const contactRes = await fetch(
+        `https://api.wildapricot.org/v2.2/accounts/${env.WILDAPRICOT_ACCOUNT_ID}/contacts/${id}`,
+        { headers: auth },
+      );
+      if (contactRes.status === 404) {
+        photoUrl = '';
+      } else if (!contactRes.ok) {
+        throw new Error(`WA contact lookup failed: ${contactRes.status}`);
+      } else {
+        const contact = await contactRes.json() as { FieldValues?: WAFieldValue[] };
+        photoUrl = extractPhotoUrl(contact.FieldValues);
+      }
+      await env.KV.put(photoUrlKey(id), photoUrl, { expirationTtl: IMAGE_TTL });
+    }
+
+    if (!photoUrl) {
+      log('gallery.photo_missing', { contactId: id });
+      return Response.redirect(new URL(PLACEHOLDER, request.url).toString(), 302);
+    }
+
+    // 2. Fetch the actual image WITH the token and stream it back publicly.
+    const imgRes = await fetch(photoUrl, { headers: auth });
+    if (!imgRes.ok) {
+      logError('gallery.photo_fetch_failed', undefined, { contactId: id, status: imgRes.status });
+      return Response.redirect(new URL(PLACEHOLDER, request.url).toString(), 302);
+    }
+
+    const response = new Response(imgRes.body, {
+      headers: {
+        'Content-Type': imgRes.headers.get('Content-Type') || 'image/png',
+        'Cache-Control': `public, max-age=${IMAGE_TTL}, s-maxage=${IMAGE_TTL}`,
+        'Access-Control-Allow-Origin': '*',
+      },
+    });
+
+    log('gallery.photo_served', { contactId: id });
+    context.waitUntil(cache.put(cacheKey, response.clone()));
+    return response;
+  } catch (err) {
+    logError('gallery.photo_error', err, { contactId: id });
+    return Response.redirect(new URL(PLACEHOLDER, request.url).toString(), 302);
+  }
+}


### PR DESCRIPTION
## Problem

Member photos never rendered in the socias gallery — all 110 cards showed the placeholder. The gallery read a **non-existent** `contact.ProfileImage` property (verified against WildApricot's official admin OpenAPI schema — no such field exists), so `profile_image_url` was always `undefined`.

The real photo lives in an **auth-gated custom Picture field** (`custom-17813785`, "Foto de Perfil") that is:
- **absent** from the async contacts list the gallery is built from, and
- served from a URL that returns **401 without a bearer token** — so a browser `<img>` can never load it directly.

WildApricot exposes no bulk public image URL via the API (confirmed on the WA developer forums; their own public site uses an opaque per-member `id` that isn't available through the API).

## Fix — photo proxy Worker

- **New** `functions/api/members/[id]/photo.ts`: resolves a contact's photo URL (cached in KV `photo_url:<id>`), fetches the image **with** the WA token, and streams it back publicly (Cache API, 24h). No photo → 302 to `/avatar-placeholder.jpg`; invalid id → 400.
- `functions/api/members.ts`: removed the dead `ProfileImage` code; each member's `profile_image_url` now points at `/api/members/{id}/photo`.
- `functions/_lib/wa-field-ids.ts`: added the `fotoPerfil` field code (the photo's only source).
- `CLAUDE.md`: updated the stale "Member photos" note.

**Trade-off:** the proxy fetches each contact on first view (cached 24h after), since the photo isn't in the bulk list — spreading WA calls across lazy-loaded visible cards rather than one heavy rebuild.

## Verification (live WildApricot, `wrangler pages dev`)

- **Daysi Cruz** (96883261): 200 image/png, 17347 bytes → renders 110×78, not placeholder ✅
- **Rocío Benavent** (96883257): 200 image/png, 16112 bytes → renders 110×110, not placeholder ✅
- `/api/members` → all 110 members wired to the proxy; gallery loaded 24 real images, 0 broken, no console errors.
- Photoless members fall back to the placeholder correctly.
- `npm run build` ✅ · lint 0 errors ✅ · tests 40/40 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)