### PR TITLE
chore(gallery): lower cache TTL to 30 min during onboarding

### DIFF
--- a/functions/api/members.ts
+++ b/functions/api/members.ts
@@ -5,7 +5,11 @@ import { FIELD_CODES } from '../_lib/wa-field-ids';
 import { log, logError } from '../_lib/logger';
 
 const KV_KEY = 'gallery_members';
-const CACHE_TTL = 86400; // 24 hours — the directory changes rarely
+// 30 min during the member-onboarding period (profiles are being imported and
+// edited frequently) so changes surface quickly. Restore to 86400 (24h) once the
+// directory stabilizes — the WA fetch is the only cost and rebuilds stay well
+// under the rate limit.
+const CACHE_TTL = 1800;
 
 interface Env {
   KV: KVNamespace;

--- a/functions/api/members/[id]/photo.ts
+++ b/functions/api/members/[id]/photo.ts
@@ -20,7 +20,9 @@ interface Env {
 
 interface WAFieldValue { SystemCode: string; Value: unknown }
 
-const IMAGE_TTL = 86400; // 24h — matches the gallery cache; photos change rarely
+// 30 min during onboarding so updated photos surface quickly; mirrors the gallery
+// cache. Restore to 86400 (24h) once the directory stabilizes.
+const IMAGE_TTL = 1800;
 const PLACEHOLDER = '/avatar-placeholder.jpg';
 
 // KV value for the contact→photo mapping. Empty string is a cached "no photo".

--- a/src/pages/SociasPage.tsx
+++ b/src/pages/SociasPage.tsx
@@ -21,7 +21,7 @@ export function SociasPage() {
   const { data: members = [], isLoading, isError, refetch } = useQuery({
     queryKey: ['gallery-members'],
     queryFn: fetchMembers,
-    staleTime: 24 * 60 * 60 * 1000, // 24h — mirrors the KV/edge cache TTL
+    staleTime: 30 * 60 * 1000, // 30 min during onboarding — mirrors the KV/edge cache TTL (restore to 24h after)
   });
 
   const {


### PR DESCRIPTION
## Why

Members are being imported and updating their profiles/photos over the coming month. At the current 24h TTL, new members and edits take up to a day to appear in the socias gallery. Lower to **30 minutes** during onboarding so changes surface quickly, then restore to 24h once the directory stabilizes.

## Changes (all three cache layers moved together)

| Layer | File | 24h → 30 min |
|---|---|---|
| Members list (KV + edge `s-maxage`) | `functions/api/members.ts` `CACHE_TTL` | `86400` → `1800` |
| Photo mapping + image (KV + Cache API + `s-maxage`) | `functions/api/members/[id]/photo.ts` `IMAGE_TTL` | `86400` → `1800` |
| Browser refetch | `src/pages/SociasPage.tsx` `staleTime` | 24h → 30 min |

Each has a comment noting to revert to 24h post-onboarding.

## Cost

The only expensive rebuild is the members-list async WildApricot fetch. At a 30-min TTL that's at most ~48 rebuilds/day — negligible against WA's ~30 req/min limit. Photo fetches are cheap and cached per-member.

`npm run build` ✅ · lint 0 errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)