### PR TITLE
chore(ci): prune audit-ci allowlist to only the react-router CVE

### DIFF
--- a/.audit-ci.jsonc
+++ b/.audit-ci.jsonc
@@ -6,30 +6,6 @@
     // react-router RSC CSRF bypass (7.12–8.2, GHSA-qwww-vcr4-c8h2).
     // MIA does not use React Server Components or framework mode — attack
     // surface absent. No non-breaking fix exists in the 7.x range.
-    "GHSA-qwww-vcr4-c8h2",
-
-    // postcss path traversal (≤8.5.22, GHSA-r28c-9q8g-f849).
-    // Fixed by dependabot PR #163 (postcss → 8.5.26). Remove after merge.
-    "GHSA-r28c-9q8g-f849",
-
-    // nanoid infinite-loop (via postcss ≤8.5.22).
-    // Fixed transitively when PR #163 lands. Remove after merge.
-    "GHSA-28wg-ghj8-5hjv",
-    "GHSA-2v37-7h3g-55p8",
-
-    // brace-expansion (via eslint / typescript-eslint, dev-only build tools).
-    // No runtime exposure. Fix available upstream but no direct dep to bump.
-    "GHSA-3jxr-9vmj-r5cp",
-    "GHSA-mh99-v99m-4gvg",
-    "GHSA-rgw5-rvv9-x895",
-
-    // undici (via workbox-build / vite-plugin-pwa, dev-only).
-    // Fixed by PR #163 (undici → 7.29.0). Remove after merge.
-    "GHSA-4cwx-7wf7-3272",
-
-    // fast-uri (via ajv / workbox-build, dev-only).
-    // Fixed by PR #163 (fast-uri → 3.1.5). Remove after merge.
-    "GHSA-7p8r-x3mc-p8w7",
-    "GHSA-v2hh-gcrm-f6hx"
+    "GHSA-qwww-vcr4-c8h2"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "globals": "^17.4.0",
         "jsdom": "^29.1.1",
         "lint-staged": "^16.3.1",
-        "postcss": "^8.5.15",
+        "postcss": "^8.5.26",
         "simple-git-hooks": "^2.13.1",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.35.1",
@@ -9670,9 +9670,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -9960,9 +9960,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -9979,7 +9979,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "globals": "^17.4.0",
     "jsdom": "^29.1.1",
     "lint-staged": "^16.3.1",
-    "postcss": "^8.5.15",
+    "postcss": "^8.5.26",
     "simple-git-hooks": "^2.13.1",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",


### PR DESCRIPTION
## Summary

Cleanup pass after this morning's batch of dependency merges (#163, #167, etc). The audit-ci allowlist was intentionally generous to keep CI moving; now that the underlying packages have been upgraded, we can trim it back to the single genuinely-required entry.

- Bumped `postcss` to 8.5.26 — the lock file was still pinned at 8.5.15 despite the semver range allowing newer, which was keeping `nanoid` and `postcss` CVEs alive.
- Removed 9 resolved entries from `.audit-ci.jsonc` (postcss, nanoid × 2, brace-expansion × 3, undici, fast-uri × 2). `audit-ci` confirms none of these advisories remain in the tree.
- Kept `GHSA-qwww-vcr4-c8h2` (react-router RSC CSRF) — still no in-range fix, still non-applicable to MIA since we don't use RSC.

## Test plan

- [ ] CI green — audit-ci passes with the trimmed allowlist
- [ ] `npm ls postcss` shows 8.5.26 across the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)